### PR TITLE
Clarify Sutra mode selection and context handling

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -46,6 +46,22 @@ Import the main module in your application:
                              
 Then use the provided classes and functions to build your simulation workflow.
 
+The :class:`SutraRepository` provides a convenient interface to call any of the
+29 Vedic sutras. Each sutra automatically selects its classical, quantum or
+hybrid implementation based on the :class:`SutraContext` mode. Example usage:
+
+```python
+from QuanQonscious import SutraRepository, SutraContext, SutraMode
+
+# create repository in classical mode
+repo = SutraRepository(SutraContext(mode=SutraMode.CLASSICAL))
+result = repo.call_sutra('ekadhikena_purvena', 5, iterations=2)
+
+# switch to quantum mode
+repo.update_context(mode=SutraMode.QUANTUM)
+quantum_result = repo.call_sutra('ekadhikena_purvena', 5, iterations=2)
+```
+
 Documentation:
 --------------
 For detailed API documentation, please refer to the “docs/” folder included in the package.

--- a/__init__.py
+++ b/__init__.py
@@ -44,6 +44,7 @@ else:
 
 # Make key submodules readily accessible via the package namespace
 from QuanQonscious import ansatz, core_engine, sulba, zpe_solver, maya_cipher, performance, updater
+from QuanQonscious.sutra_repository import SutraRepository
 
 # Optionally, set a flag or config dict for use in modules (for example, default quantum backend choice)
 DEFAULT_QUANTUM_BACKEND = "cudaq" if _has_cudaq else "cirq"

--- a/primarysutra.py
+++ b/primarysutra.py
@@ -2445,10 +2445,13 @@ class VedicSutras:
         """Classical implementation of yavadunam"""
         return base - x
 
-def samuccayagunitah(self, a: Union[float, np.ndarray, torch.Tensor],
-                        b: Union[float, np.ndarray, torch.Tensor],
-                        operation: str = 'product_sum',
-                        ctx: Optional[SutraContext] = None) -> Union[float, np.ndarray, torch.Tensor]:
+    def samuccayagunitah(
+        self,
+        a: Union[float, np.ndarray, torch.Tensor],
+        b: Union[float, np.ndarray, torch.Tensor],
+        operation: str = 'product_sum',
+        ctx: Optional[SutraContext] = None,
+    ) -> Union[float, np.ndarray, torch.Tensor]:
         """
         Sutra 15: Samuccayagunitah - "The product of the sum is equal to the sum of the products"
         

--- a/primarysutra.py
+++ b/primarysutra.py
@@ -311,11 +311,39 @@ class VedicSutras:
             
             # Convert back to original type
             result = self._from_device(result, original_type)
-            
+
             end_time = time.time()
-def paravartya_yojayet(self, x: Union[float, np.ndarray, torch.Tensor],
-                          divisor: Union[float, np.ndarray, torch.Tensor],
-                          ctx: Optional[SutraContext] = None) -> Union[float, np.ndarray, torch.Tensor]:
+            self._record_performance(
+                "nikhilam_navatashcaramam_dashatah",
+                start_time,
+                end_time,
+                True,
+                data_size,
+            )
+            return result
+
+        except Exception as e:
+            end_time = time.time()
+            error_msg = str(e)
+            logger.error(
+                f"Error in nikhilam_navatashcaramam_dashatah: {error_msg}"
+            )
+            self._record_performance(
+                "nikhilam_navatashcaramam_dashatah",
+                start_time,
+                end_time,
+                False,
+                data_size,
+                error_msg,
+            )
+            raise
+
+    def paravartya_yojayet(
+        self,
+        x: Union[float, np.ndarray, torch.Tensor],
+        divisor: Union[float, np.ndarray, torch.Tensor],
+        ctx: Optional[SutraContext] = None,
+    ) -> Union[float, np.ndarray, torch.Tensor]:
         """
         Sutra 3: Paravartya Yojayet - "Transpose and Apply"
         

--- a/sutra_repository.py
+++ b/sutra_repository.py
@@ -1,0 +1,59 @@
+from typing import Any, Callable, Dict, List, Optional
+
+from .primarysutra import VedicSutras, SutraContext, SutraMode
+
+class SutraRepository:
+    """Lightweight wrapper exposing all sutras as callable functions."""
+
+    def __init__(self, context: Optional[SutraContext] = None) -> None:
+        self._sutras = VedicSutras(context)
+        self._methods: Dict[str, Callable] = self._discover_sutras()
+
+    def _discover_sutras(self) -> Dict[str, Callable]:
+        """Collect all callable sutra methods from :class:`VedicSutras`."""
+        methods: Dict[str, Callable] = {}
+        for name in dir(self._sutras):
+            if name.startswith("_"):
+                continue
+            attr = getattr(self._sutras, name)
+            if callable(attr):
+                methods[name] = attr
+        return methods
+
+    @property
+    def context(self) -> SutraContext:
+        return self._sutras.context
+
+    def list_sutras(self) -> List[str]:
+        """Return available sutra names."""
+        return sorted(self._methods.keys())
+
+    def call_sutra(self, name: str, *args, ctx: Optional[SutraContext] = None,
+                   **kwargs) -> Any:
+        """Invoke a sutra by name with the provided arguments.
+
+        Parameters
+        ----------
+        name : str
+            The sutra method to invoke.
+        ctx : Optional[SutraContext], optional
+            Execution context override. If omitted, the repository's current
+            :class:`SutraContext` is used.
+        *args, **kwargs :
+            Arguments forwarded to the sutra implementation.
+        """
+        func = self._methods.get(name)
+        if func is None:
+            raise ValueError(f"Unknown sutra: {name}")
+
+        # Ensure a context is passed if the sutra implementation accepts one
+        if 'ctx' not in kwargs:
+            kwargs['ctx'] = ctx or self.context
+
+        return func(*args, **kwargs)
+
+    def update_context(self, **kwargs: Any) -> None:
+        """Update attributes of the underlying :class:`SutraContext`."""
+        for key, value in kwargs.items():
+            if hasattr(self._sutras.context, key):
+                setattr(self._sutras.context, key, value)


### PR DESCRIPTION
## Summary
- document that SutraRepository chooses classical, quantum or hybrid implementation based on `SutraContext.mode`
- show how to update the context and call the quantum variant
- pass context through `call_sutra` for explicit overrides and remove unused import

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` *(fails: undefined names, syntax errors in unrelated files)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ba54ae508332b906d36bd295fc86