### PR TITLE
Fix CLI imports and package path

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,8 @@
 # QuanQonscious/__init__.py
 
+# Import importlib along with its util submodule for feature detection
 import importlib
+import importlib.util
 import os
 
 # Check for NVIDIA CUDA Quantum library (CUDA-Q) support
@@ -43,7 +45,10 @@ else:
     print("[QuanQonscious] CUDA-Q not available – defaulting to Cirq simulator for quantum circuits.")
 
 # Make key submodules readily accessible via the package namespace
-from QuanQonscious import ansatz, core_engine, sulba, zpe_solver, maya_cipher, performance, updater
+# Import key submodules using relative imports so the package functions
+# correctly even if the directory name does not match the canonical
+# "QuanQonscious" package name used in setup.py.
+from . import ansatz, core_engine, sulba, zpe_solver, maya_cipher, performance, updater
 
 # Optionally, set a flag or config dict for use in modules (for example, default quantum backend choice)
 DEFAULT_QUANTUM_BACKEND = "cudaq" if _has_cudaq else "cirq"

--- a/ansatz.py
+++ b/ansatz.py
@@ -8,7 +8,9 @@ try:
 except ImportError:
     cudaq = None
 
-from QuanQonscious import core_engine, maya_cipher
+# Use relative imports so the module works regardless of the package name on
+# disk.
+from . import core_engine, maya_cipher
 
 class GRVQAnsatz:
     """

--- a/cli.py
+++ b/cli.py
@@ -1,7 +1,10 @@
 # QuanQonscious/cli.py
 
 import argparse
-from QuanQonscious import ansatz, maya_cipher, updater, zpe_solver
+# Import package modules using relative paths so the CLI works even when the
+# repository directory name differs from the package name used in setup.py.
+from . import ansatz, maya_cipher, updater, zpe_solver
+import numpy as np
 
 def main():
     parser = argparse.ArgumentParser(prog="quanqonscious", 


### PR DESCRIPTION
## Summary
- use relative imports in package modules
- import numpy in CLI
- expose importlib.util in `__init__`

## Testing
- `python -m quanqonscious.cli simulate --size 10 10 10 --steps 2`
- `python - <<'EOF'
from quanqonscious.zpe_solver import ZPEFieldSolver
import numpy as np
solver = ZPEFieldSolver((10,10,10), dt=0.1)
solver.set_initial_field(lambda X,Y,Z: np.exp(-0.1*((X-5)**2+(Y-5)**2+(Z-5)**2)))
solver.step(2)
field = solver.get_field()
print(field.shape, field[5,5,5])
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6868565f86c083328afce4256e49a941