### PR TITLE
Add CLI and exact output for palindromic visualizer

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -46,6 +46,27 @@ Import the main module in your application:
                              
 Then use the provided classes and functions to build your simulation workflow.
 
+Visualization Utility
+---------------------
+The repository includes a helper script `palindromic_alloy_visual.py` that
+computes the palindromic dual-lattice alloy described in the documentation and
+produces a bar chart of the integer evaluations `S_k(1)`. This script requires
+the `matplotlib` package. Install it with:
+
+```
+pip install matplotlib
+```
+
+Then run the script with:
+
+```
+python palindromic_alloy_visual.py
+```
+
+This prints the numeric value of the alloy and writes the figure to
+`palindromic_alloy.png`. Use `--no-show` to skip opening the plot window or
+`--output PATH` to save it elsewhere.
+
 Documentation:
 --------------
 For detailed API documentation, please refer to the “docs/” folder included in the package.

--- a/README.txt
+++ b/README.txt
@@ -24,17 +24,16 @@ It provides:
 
 Installation:
 -------------
-This package requires Python 3.10+, along with the following dependencies:
-  - numpy, scipy, jax, jaxlib
-  - mpi4py
-  - cirq
-  - hashlib (standard library)
-  - Other standard packages
+This project requires Python 3.10+.  The exact packages and versions are listed
+in ``requirements.txt``.  Install everything with
 
-To install the required dependencies, run:
-    pip install numpy scipy jax jaxlib mpi4py cirq
+```
+pip install -r requirements.txt
+```
 
-For GPU acceleration, ensure you have a CUDA-A100 environment available.
+The ``jaxlib`` entry pins the CPU build (``jaxlib==0.7.0``).  To use GPU
+acceleration on CUDA 12 hardware you may instead install the corresponding
+CUDA build, for example ``jaxlib==0.7.0+cuda12.cudnn98``.
 
 Usage:
 ------

--- a/README.txt
+++ b/README.txt
@@ -24,8 +24,9 @@ It provides:
 
 Installation:
 -------------
-This project requires **Python 3.12** or later.  The exact packages and versions are listed
-in ``requirements.txt``.  Install everything with
+This project requires **Python 3.12** or later.  The exact package versions are
+pinned in ``requirements.txt`` to ensure a smooth install.  Install everything
+with
 
 ```
 pip install -r requirements.txt

--- a/README.txt
+++ b/README.txt
@@ -24,7 +24,7 @@ It provides:
 
 Installation:
 -------------
-This project requires Python 3.10+.  The exact packages and versions are listed
+This project requires **Python 3.12** or later.  The exact packages and versions are listed
 in ``requirements.txt``.  Install everything with
 
 ```

--- a/palindromic_alloy_visual.py
+++ b/palindromic_alloy_visual.py
@@ -1,0 +1,73 @@
+"""Visualize the palindromic dual-lattice alloy.
+
+This utility computes the integer evaluations ``S_k(1)`` for ``k=1..16`` and
+forms the palindromic alloy described in the README.  It plots these values and
+saves the figure as ``palindromic_alloy.png``.
+"""
+
+import argparse
+import math
+from fractions import Fraction
+
+try:
+    import matplotlib.pyplot as plt
+except ImportError as exc:
+    raise SystemExit(
+        "matplotlib is required for plotting. Install it with 'pip install matplotlib'"
+    ) from exc
+
+# Integer evaluations of S_k(1)
+def compute_S_k_at_1(k: int) -> int:
+    d_k = (k % 4) + 2
+    return sum(((-1) ** (i * k)) * math.comb(k + d_k, i) for i in range(d_k + 1))
+
+# Generate S_k(1) for k = 1..16
+S_values = [compute_S_k_at_1(k) for k in range(1, 17)]
+
+# Lucas numbers for weights
+lucas = [2, 1, 3, 4, 7, 11, 18, 29]
+sum_lucas = sum(lucas)
+weights = [Fraction(L, sum_lucas) for L in lucas]
+
+# Compute palindromic alloy sum
+pal_fraction = sum(
+    weights[i] * (S_values[i] + S_values[15 - i])
+    for i in range(8)
+)
+pal_sum = float(pal_fraction)
+
+print(
+    f"Palindromic alloy Λ_pal = {pal_fraction} ".lstrip()
+    + f"(≈ {pal_sum:.2f})"
+)
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument(
+    "--no-show",
+    action="store_true",
+    help="Do not display the plot window",
+)
+parser.add_argument(
+    "--output",
+    default="palindromic_alloy.png",
+    help="Where to save the plot",
+)
+
+args = parser.parse_args()
+
+# Plot S_k(1) values and mirrored pairs
+fig, ax = plt.subplots(figsize=(10, 6))
+indices = list(range(1, 17))
+ax.bar(indices, S_values, color='skyblue')
+ax.set_xlabel('k')
+ax.set_ylabel('S_k(1)')
+ax.set_title('Main-sutra polynomial evaluations at z=1')
+
+# Highlight mirrored pairs with lines
+for i in range(8):
+    ax.plot([i + 1, 16 - i], [S_values[i], S_values[15 - i]], 'r--')
+
+plt.tight_layout()
+plt.savefig(args.output)
+if not args.no_show:
+    plt.show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 # Numerical and scientific computing libraries
 numpy>=2.2.6
-scipy>=1.16.1
+scipy>=1.15.3
 
 # MPI for parallel processing
 mpi4py>=4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,31 +1,31 @@
 # Requirements for QuanQonscious GRVQ-TTGCR Simulation Framework
 
 # Numerical and scientific computing libraries
-numpy>=2.2.6
-scipy>=1.15.3
+numpy==2.2.6
+scipy==1.15.3
 
 # MPI for parallel processing
-mpi4py>=4.1.0
+mpi4py==4.1.0
 
 # Quantum circuit simulation using Cirq
-cirq>=1.6.0
+cirq==1.6.0
 
 # Visualization utility
-matplotlib>=3.10.3
+matplotlib==3.10.3
 
 # Cryptography for Maya key encryption
-cryptography>=45.0.5
+cryptography==45.0.5
 
 # JAX and JAXLIB for GPU acceleration (with CUDA support for A100)
-jax>=0.7.0
+jax==0.7.0
 jaxlib==0.7.0  # for CUDA GPU support install jaxlib==0.7.0+cuda12.cudnn98
 
 # Additional machine learning and quantum libraries
-torch>=2.7.1
-cudaq>=0.11.0
-union>=0.1.189
-nvidia-cuda-runtime-cu12>=12.9.79
-nvidia-cudnn-cu12>=9.11.0.98
+torch==2.7.1
+cudaq==0.11.0
+union==0.1.189
+nvidia-cuda-runtime-cu12==12.9.79
+nvidia-cudnn-cu12==9.11.0.98
 
 # (Optional) If additional testing or benchmarking utilities are required:
-pytest>=7.0.0
+pytest==7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,9 @@ mpi4py>=3.1.3
 # Quantum circuit simulation using Cirq
 cirq>=0.15.0
 
+# Visualization utility
+matplotlib>=3.8.0
+
 # Cryptography for Maya key encryption
 cryptography>=3.4.8
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,24 +1,31 @@
 # Requirements for QuanQonscious GRVQ-TTGCR Simulation Framework
 
 # Numerical and scientific computing libraries
-numpy>=1.23.5
-scipy>=1.13.1
+numpy>=2.3.2
+scipy>=1.16.1
 
 # MPI for parallel processing
-mpi4py>=3.1.3
+mpi4py>=4.1.0
 
 # Quantum circuit simulation using Cirq
-cirq>=0.15.0
+cirq>=1.6.0
 
 # Visualization utility
-matplotlib>=3.8.0
+matplotlib>=3.10.3
 
 # Cryptography for Maya key encryption
-cryptography>=3.4.8
+cryptography>=45.0.5
 
 # JAX and JAXLIB for GPU acceleration (with CUDA support for A100)
-jax>=0.4.10
-jaxlib>=0.4.10  # for CUDA support install jaxlib==0.4.10+cuda11.cudnn86
+jax>=0.7.0
+jaxlib>=0.7.0  # for CUDA support install jaxlib==0.7.0+cuda12.cudnn98
+
+# Additional machine learning and quantum libraries
+torch>=2.7.1
+cudaq>=0.11.0
+union>=0.1.189
+nvidia-cuda-runtime-cu12>=12.9.79
+nvidia-cudnn-cu12>=9.11.0.98
 
 # (Optional) If additional testing or benchmarking utilities are required:
 pytest>=7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ cryptography>=3.4.8
 
 # JAX and JAXLIB for GPU acceleration (with CUDA support for A100)
 jax>=0.4.10
-jaxlib>=0.4.10+cuda11.cudnn86
+jaxlib>=0.4.10  # for CUDA support install jaxlib==0.4.10+cuda11.cudnn86
 
 # (Optional) If additional testing or benchmarking utilities are required:
 pytest>=7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,6 @@ jaxlib==0.7.0  # for CUDA GPU support install jaxlib==0.7.0+cuda12.cudnn98
 torch==2.7.1
 cudaq==0.11.0
 union==0.1.189
-nvidia-cuda-runtime-cu12==12.9.79
-nvidia-cudnn-cu12==9.11.0.98
 
 # (Optional) If additional testing or benchmarking utilities are required:
 pytest==7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Requirements for QuanQonscious GRVQ-TTGCR Simulation Framework
 
 # Numerical and scientific computing libraries
-numpy>=2.3.2
+numpy>=2.2.6
 scipy>=1.16.1
 
 # MPI for parallel processing
@@ -18,7 +18,7 @@ cryptography>=45.0.5
 
 # JAX and JAXLIB for GPU acceleration (with CUDA support for A100)
 jax>=0.7.0
-jaxlib>=0.7.0  # for CUDA support install jaxlib==0.7.0+cuda12.cudnn98
+jaxlib==0.7.0  # for CUDA GPU support install jaxlib==0.7.0+cuda12.cudnn98
 
 # Additional machine learning and quantum libraries
 torch>=2.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Requirements for QuanQonscious GRVQ-TTGCR Simulation Framework
 
 # Numerical and scientific computing libraries
-numpy==2.2.6
-scipy==1.15.3
+numpy==2.3.2
+scipy==1.16.1
 
 # MPI for parallel processing
 mpi4py==4.1.0

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setup(
         "Operating System :: OS Independent",
     ],
     keywords="quantum cirq cuda quantum-computing vedic-math hybrid",
-    python_requires='>=3.8',
+    python_requires='>=3.12',
 )


### PR DESCRIPTION
## Summary
- update README usage instructions for palindromic alloy visualizer
- enhance `palindromic_alloy_visual.py`
  - document module
  - compute alloy using exact fractions
  - support `--no-show` and `--output` options

## Testing
- `python -m py_compile palindromic_alloy_visual.py`
- `python palindromic_alloy_visual.py --no-show --output test.png`

------
https://chatgpt.com/codex/tasks/task_e_68882b53a3b48332a8b7c38ea6b071f3