### PR TITLE
Align PCFE CuPy wheel usage with prebuilt strategy

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,10 +23,18 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.10"
+    - name: Install CUDA toolkit (runtime only)
+      uses: Jimver/cuda-toolkit@v0
+      with:
+        cuda: "11.8.0"
     - name: Install dependencies
+      env:
+        CFLAGS: "-I/usr/local/cuda/include"
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
+        # Use precompiled CuPy wheels to avoid source builds and missing headers
+        pip install cupy-cuda11x
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/pcfe-v3/docker/Dockerfile
+++ b/pcfe-v3/docker/Dockerfile
@@ -30,8 +30,8 @@ RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
 # Install CUDA-Quantum (requires specific installation)
 RUN pip3 install cuda-quantum==0.6.0 --extra-index-url https://pypi.nvidia.com
 
-# Install CuPy for CUDA 11.8
-RUN pip3 install cupy-cuda11x
+# Install CuPy for CUDA 11.8 using precompiled wheel
+RUN pip3 install cupy-cuda11x==13.0.0
 
 # Copy source code
 COPY src/ /app/src/

--- a/pcfe-v3/docker/requirements.txt
+++ b/pcfe-v3/docker/requirements.txt
@@ -5,8 +5,8 @@ torch==2.1.0+cu118  # CUDA 11.8 version
 matplotlib==3.7.2
 seaborn==0.12.2
 
-# GPU computing
-cupy-cuda11x==12.2.0
+# GPU computing (precompiled CuPy wheels to avoid source builds)
+cupy-cuda11x==13.0.0
 numba==0.58.0
 
 # Quantum computing

--- a/pcfe-v3/setup.py
+++ b/pcfe-v3/setup.py
@@ -1,22 +1,15 @@
-from setuptools import setup, find_packages
-
-setup(
-    name="pcfe-v3",
-    version="0.1.0",
-    packages=find_packages(where="src"),
-    package_dir={"": "src"},
-    install_requires=[
-        "numpy",
-        "mpi4py",#!/usr/bin/env python3
+#!/usr/bin/env python3
 """
-Setup script for Proto-Consciousness Field Engine (PCFE) v3.0
+Setup script for Proto-Consciousness Field Engine (PCFE) v3.0.
+This config favors precompiled CUDA wheels to avoid source builds and keeps
+CUDA 11.x/12.x variants aligned with the main CuPy dependency strategy.
 """
 
-from setuptools import setup, find_packages
-from pathlib import Path
 import sys
+from pathlib import Path
+from setuptools import find_packages, setup
 
-# Check Python version
+# Enforce supported Python
 if sys.version_info < (3, 10):
     print("Error: PCFE requires Python 3.10 or later")
     sys.exit(1)
@@ -33,65 +26,65 @@ install_requires = [
     "torch>=2.1.0",
     "matplotlib>=3.7.2",
     "seaborn>=0.12.2",
-    
+
     # Quantum computing
     # Note: cuda-quantum and qiskit need separate installation
     "cirq>=1.2.0",
-    
+
     # GPU computing
-    # Note: cupy needs CUDA-specific version
+    # Note: CuPy needs CUDA-specific version
     "numba>=0.58.0",
-    
+
     # MPI
     "mpi4py>=3.1.4",
-    
+
     # Data handling
     "h5py>=3.9.0",
     "zarr>=2.16.1",
     "pandas>=2.0.3",
-    
+
     # Visualization
     "plotly>=5.17.0",
     "vispy>=0.13.0",
     "pyvista>=0.42.2",
-    
+
     # ML/Analysis
     "scikit-learn>=1.3.1",
     "networkx>=3.1",
     "tensornetwork>=0.4.6",
     "opt-einsum>=3.3.0",
-    
+
     # Utilities
     "pyyaml>=6.0.1",
     "dill>=0.3.7",
     "aiofiles>=23.2.1",
     "psutil>=5.9.5",
     "GPUtil>=1.4.0",
-    
+
     # Testing
     "pytest>=7.4.2",
     "hypothesis>=6.87.0",
-    
+
     # Deployment
     "docker>=6.1.3",
     "kubernetes>=28.1.0",
 ]
 
-# Optional dependencies
+# Optional dependencies (align CUDA wheels with main project policy)
 extras_require = {
-    'cuda11': ['cupy-cuda11x>=12.2.0'],
-    'cuda12': ['cupy-cuda12x>=12.2.0'],
-    'quantum': ['cuda-quantum==0.6.0', 'qiskit>=0.45.0'],
-    'viz': ['vtk>=9.2.6', 'mayavi>=4.8.1', 'napari>=0.4.18'],
-    'dev': [
-        'black>=23.9.1',
-        'flake8>=6.1.0',
-        'mypy>=1.5.1',
-        'pre-commit>=3.4.0',
-        'sphinx>=7.2.6',
-        'sphinx-rtd-theme>=1.3.0',
+    "cuda11": ["cupy-cuda11x>=13.0.0"],
+    "cuda12": ["cupy-cuda12x>=13.0.0"],
+    "quantum": ["cuda-quantum==0.6.0", "qiskit>=0.45.0"],
+    "viz": ["vtk>=9.2.6", "mayavi>=4.8.1", "napari>=0.4.18"],
+    "dev": [
+        "black>=23.9.1",
+        "flake8>=6.1.0",
+        "mypy>=1.5.1",
+        "pre-commit>=3.4.0",
+        "sphinx>=7.2.6",
+        "sphinx-rtd-theme>=1.3.0",
     ],
-    'all': [],  # Will be populated below
+    "all": [],  # Populated below
 }
 
 # Combine all extras
@@ -99,7 +92,7 @@ all_extras = []
 for extra in extras_require.values():
     if isinstance(extra, list):
         all_extras.extend(extra)
-extras_require['all'] = list(set(all_extras))
+extras_require["all"] = list(set(all_extras))
 
 setup(
     name="pcfe",
@@ -115,14 +108,14 @@ setup(
         "Documentation": "https://pcfe.readthedocs.io",
         "Source Code": "https://github.com/YOUR_USERNAME/pcfe-v3",
     },
-    
+
     # Package configuration
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     python_requires=">=3.10",
     install_requires=install_requires,
     extras_require=extras_require,
-    
+
     # Include additional files
     include_package_data=True,
     package_data={
@@ -132,7 +125,7 @@ setup(
             "docker/requirements.txt",
         ],
     },
-    
+
     # Entry points
     entry_points={
         "console_scripts": [
@@ -142,7 +135,7 @@ setup(
             "pcfe-validate=pcfe_validation_deployment:run_all_validations",
         ],
     },
-    
+
     # Classifiers
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -158,11 +151,11 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Framework :: Pytest",
     ],
-    
+
     keywords=[
         "quantum computing",
         "consciousness",
-        "physics simulation", 
+        "physics simulation",
         "cuda",
         "mpi",
         "scientific computing",
@@ -171,17 +164,18 @@ setup(
     ],
 )
 
-# Post-installation message
-print("""
+# Post-installation message emphasising precompiled CUDA wheels
+print(
+    """
 ╔══════════════════════════════════════════════════════════════════════════╗
 ║  PCFE v3.0 Installation Complete!                                        ║
 ╚══════════════════════════════════════════════════════════════════════════╝
 
 Next steps:
 
-1. Install CUDA-specific packages:
-   - For CUDA 11.x: pip install cupy-cuda11x cuda-quantum
-   - For CUDA 12.x: pip install cupy-cuda12x cuda-quantum
+1. Install CUDA-specific packages using precompiled wheels (no source builds):
+   - For CUDA 11.x: pip install cupy-cuda11x==13.0.0 cuda-quantum==0.6.0
+   - For CUDA 12.x: pip install cupy-cuda12x==13.0.0 cuda-quantum==0.6.0
 
 2. Verify installation:
    pcfe --test
@@ -193,7 +187,5 @@ Next steps:
    mpirun -n 4 pcfe --distributed
 
 Documentation: https://github.com/YOUR_USERNAME/pcfe-v3
-""")
-        "matplotlib"
-    ],
+"""
 )

--- a/pcfe-v3/src/pcfe_validation_deployment.py
+++ b/pcfe-v3/src/pcfe_validation_deployment.py
@@ -1024,7 +1024,7 @@ CMD ["python3", "pcfe_v3_core_engine.py"]
 numpy==1.24.3
 scipy==1.11.3
 torch==2.1.0+cu118
-cupy-cuda11x==12.2.0
+cupy-cuda11x==13.0.0
 numba==0.58.0
 matplotlib==3.7.2
 seaborn==0.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,9 @@ cirq>=0.15.0
 qiskit>=0.45.0
 qiskit-aer>=0.12.0
 
+# GPU array computing (precompiled CUDA 11.x wheels to avoid source builds)
+cupy-cuda11x>=13.0.0
+
 # Cryptography for Maya key encryption
 cryptography>=3.4.8
 blake3>=1.0.8

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
         "qiskit-aer>=0.12.0",
     ],
     extras_require={
-        "gpu": ["cupy>=9.0.0", "cuda-quantum-cu12>=0.1.0"],
+        # Use precompiled CUDA 11.x wheel to avoid building CuPy from source
+        "gpu": ["cupy-cuda11x>=13.0.0", "cuda-quantum-cu12>=0.1.0"],
         "dev": ["numba>=0.55", "psutil>=5.8"]
     },
     entry_points={


### PR DESCRIPTION
## Summary
- rewrite the pcfe-v3 setup script to cleanly declare dependencies and align optional CUDA extras with precompiled CuPy 13.0.0 wheels
- update container requirements and Dockerfile to install the prebuilt cupy-cuda11x 13.0.0 wheel instead of the older 12.x build
- refresh the autogenerated validation requirements to pin the same CuPy wheel version

## Testing
- pytest (skipped: missing optional cudaq/torch dependencies)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937d2c3d6cc8332bd8189da402947b7)