### PR TITLE
Add hybrid sutra orchestration and serial/concurrent/parallel execution to GRVQ pipeline

### DIFF
--- a/grvq_toroidal_hypercube.py
+++ b/grvq_toroidal_hypercube.py
@@ -24,17 +24,22 @@ Based on methods from:
 ═══════════════════════════════════════════════════════════════════════════════
 """
 
+import logging
 import math
 import numpy as np
+import primarysutra
 from fractions import Fraction
 from typing import List, Tuple, Dict, Any, Union, Optional
-from dataclasses import dataclass
-from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field, replace
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
+from primarysutra import SutraContext, SutraMode, VedicSutras
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # SECTION 1: FUNDAMENTAL CONSTANTS (EXACT ARITHMETIC)
 # ═══════════════════════════════════════════════════════════════════════════════
+
+logger = logging.getLogger("GRVQToroidalHypercube")
 
 class FundamentalConstants:
     """Exact fundamental constants using Fraction arithmetic."""
@@ -340,9 +345,18 @@ class VedicSutraEngine:
         return result
 
     @classmethod
-    def apply_subsutras_parallel(cls, params: np.ndarray,
-                                  max_workers: int = 8) -> np.ndarray:
-        """Apply all 13 sub-sutras in parallel and average results."""
+    def apply_subsutras_serial(cls, params: np.ndarray) -> np.ndarray:
+        """Apply all 13 sub-sutras sequentially and average results."""
+        results = []
+        for sub in cls.SUB_SUTRAS:
+            results.append(sub(params))
+        stacked = np.vstack(results)
+        return np.mean(stacked, axis=0)
+
+    @classmethod
+    def apply_subsutras_concurrent(cls, params: np.ndarray,
+                                   max_workers: int = 8) -> np.ndarray:
+        """Apply all 13 sub-sutras concurrently with threads and average results."""
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = [executor.submit(sub, params) for sub in cls.SUB_SUTRAS]
             results = [f.result() for f in futures]
@@ -351,9 +365,21 @@ class VedicSutraEngine:
         return np.mean(stacked, axis=0)
 
     @classmethod
+    def apply_subsutras_parallel(cls, params: np.ndarray,
+                                 max_workers: int = 8) -> np.ndarray:
+        """Apply all 13 sub-sutras in parallel with processes and average results."""
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+            futures = [executor.submit(sub, params) for sub in cls.SUB_SUTRAS]
+            results = [f.result() for f in futures]
+
+        stacked = np.vstack(results)
+        return np.mean(stacked, axis=0)
+
+    @classmethod
     def apply_all_29_sutras(cls, params: np.ndarray,
-                            max_workers: int = 8) -> np.ndarray:
-        """Apply all 29 sutras: 16 primary (serial) + 13 sub (parallel)."""
+                            max_workers: int = 8,
+                            execution_mode: str = "concurrent") -> np.ndarray:
+        """Apply all 29 sutras with selectable execution strategy."""
         # Sanitize input - replace NaN/Inf with bounded values
         params = np.nan_to_num(params, nan=0.0, posinf=1e6, neginf=-1e6)
         params = np.clip(params, -1e6, 1e6)
@@ -364,12 +390,95 @@ class VedicSutraEngine:
         intermediate = np.nan_to_num(intermediate, nan=0.0, posinf=1e6, neginf=-1e6)
         intermediate = np.clip(intermediate, -1e6, 1e6)
 
-        final = cls.apply_subsutras_parallel(intermediate, max_workers)
+        if execution_mode == "serial":
+            final = cls.apply_subsutras_serial(intermediate)
+        elif execution_mode == "parallel":
+            final = cls.apply_subsutras_parallel(intermediate, max_workers)
+        else:
+            final = cls.apply_subsutras_concurrent(intermediate, max_workers)
 
         # Sanitize output
         final = np.nan_to_num(final, nan=0.0, posinf=1e6, neginf=-1e6)
         return final
 
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SECTION 5B: HYBRID QUANTUM-CLASSICAL SUTRA COORDINATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def _quantum_available() -> bool:
+    cirq_module = getattr(primarysutra, "cirq", None)
+    cudaq_module = getattr(primarysutra, "cudaq", None)
+    return (cirq_module is not None and hasattr(cirq_module, "Simulator")) or cudaq_module is not None
+
+
+@dataclass
+class SutraExecutionPlan:
+    """Execution plan for 29-sutra runs with optional quantum augmentation."""
+    context: SutraContext = field(default_factory=SutraContext)
+    execution_mode: str = "concurrent"
+    max_workers: int = 8
+
+    def effective_context(self) -> SutraContext:
+        if self.context.mode in (SutraMode.QUANTUM, SutraMode.HYBRID) and not _quantum_available():
+            logger.warning(
+                "Quantum backend unavailable; downgrading sutra execution to classical mode."
+            )
+            return replace(self.context, mode=SutraMode.CLASSICAL)
+        return self.context
+
+
+class HybridSutraCoordinator:
+    """
+    Apply 29 sutras with serial/concurrent/parallel control and optional
+    quantum-classical augmentation for hybrid simulators.
+    """
+
+    def __init__(self, plan: Optional[SutraExecutionPlan] = None):
+        self.plan = plan or SutraExecutionPlan()
+
+    def _quantum_correction(self, stats: Dict[str, float], context: SutraContext) -> float:
+        """
+        Compute a deterministic correction using quantum-capable sutras.
+        Returns a scalar correction applied to the transformed field.
+        """
+        sutras = VedicSutras(context)
+        mean_val = stats["mean"]
+        spread = stats["std"]
+        energy = stats["l2"]
+        base_val = context.base if context.base != 0 else 10.0
+        divisor = max(1.0, abs(mean_val) + 1.0)
+
+        step1 = sutras.ekadhikena_purvena(mean_val, iterations=2, ctx=context)
+        step2 = sutras.nikhilam_navatashcaramam_dashatah(step1, base=base_val, ctx=context)
+        step3 = sutras.chalana_kalana(step2, steps=3, direction=1, ctx=context)
+        step4 = sutras.sankalana_vyavakalanabhyam(step3, spread, operation="add", ctx=context)
+        step5 = sutras.gunitasamuccayah(step4, energy / divisor, ctx=context)
+
+        return float(step5)
+
+    def apply(self, params: np.ndarray) -> np.ndarray:
+        """
+        Apply the 29 sutras with the configured execution strategy and, when
+        requested, apply a quantum-derived correction to the result.
+        """
+        effective_context = self.plan.effective_context()
+        transformed = VedicSutraEngine.apply_all_29_sutras(
+            params,
+            max_workers=self.plan.max_workers,
+            execution_mode=self.plan.execution_mode,
+        )
+
+        if effective_context.mode == SutraMode.CLASSICAL:
+            return transformed
+
+        stats = {
+            "mean": float(np.mean(transformed)),
+            "std": float(np.std(transformed)),
+            "l2": float(np.linalg.norm(transformed)),
+        }
+        correction = self._quantum_correction(stats, effective_context)
+        return transformed + correction * 1e-3
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # SECTION 6: 4D TESSERACT (HYPERCUBE)
@@ -656,11 +765,13 @@ class GRVQToroidalHypercube:
     """
 
     def __init__(self, R_major: float = 0.6, R_minor: float = 0.3,
-                 tesseract_scale: float = 0.35, R0: float = 1.0):
+                 tesseract_scale: float = 0.35, R0: float = 1.0,
+                 sutra_plan: Optional[SutraExecutionPlan] = None):
         self.torus = ToroidalGeometry(R_major, R_minor)
         self.tesseract = Tesseract4D(scale=tesseract_scale)
         self.ansatz = GRVQAnsatz(R0=R0)
-        self.vedic_engine = VedicSutraEngine()
+        self.sutra_plan = sutra_plan or SutraExecutionPlan()
+        self.sutra_coordinator = HybridSutraCoordinator(self.sutra_plan)
 
         # Wheeler coupling constant
         self.kappa = float(FundamentalConstants.wheeler_coupling())
@@ -739,13 +850,17 @@ class GRVQToroidalHypercube:
             'metric_tensor': g
         }
 
-    def apply_vedic_transformation(self, field_values: np.ndarray) -> np.ndarray:
-        """Apply all 29 Vedic sutras to field values."""
-        return self.vedic_engine.apply_all_29_sutras(field_values)
+    def apply_vedic_transformation(self, field_values: np.ndarray,
+                                   sutra_plan: Optional[SutraExecutionPlan] = None) -> np.ndarray:
+        """Apply all 29 Vedic sutras to field values with execution control."""
+        if sutra_plan is not None:
+            return HybridSutraCoordinator(sutra_plan).apply(field_values)
+        return self.sutra_coordinator.apply(field_values)
 
     def compute_full_system(self, n_points: int = 50,
                              m: int = 3, n: int = 5,
-                             angle_xw: float = 0.4) -> Dict[str, Any]:
+                             angle_xw: float = 0.4,
+                             sutra_plan: Optional[SutraExecutionPlan] = None) -> Dict[str, Any]:
         """
         Compute the complete GRVQ toroidal hypercube system.
 
@@ -764,7 +879,7 @@ class GRVQToroidalHypercube:
 
         # Apply Vedic transformation
         flat_field = field_grid.flatten()
-        transformed = self.apply_vedic_transformation(flat_field)
+        transformed = self.apply_vedic_transformation(flat_field, sutra_plan=sutra_plan)
         field_transformed = transformed.reshape((n_points, n_points))
 
         # Tesseract vertex fields

--- a/hybrid_grvq_toroidal_simulator.py
+++ b/hybrid_grvq_toroidal_simulator.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+import numpy as np
+
+from grvq_toroidal_hypercube import GRVQToroidalHypercube, SutraExecutionPlan
+from primarysutra import SutraContext, SutraMode
+
+
+@dataclass
+class HybridSimulationConfig:
+    """Configuration for hybrid quantum-classical toroidal hypercube runs."""
+    n_points: int = 50
+    m_mode: int = 3
+    n_mode: int = 5
+    angle_xw: float = 0.4
+    execution_mode: str = "concurrent"
+    max_workers: int = 8
+    sutra_mode: SutraMode = SutraMode.CLASSICAL
+    sutra_base: float = 10.0
+
+
+class HybridGRVQToroidalSimulator:
+    """
+    Orchestrates a hybrid quantum-classical simulation using the 29 Vedic sutras
+    with selectable serial, concurrent, or parallel execution.
+    """
+
+    def __init__(self, config: HybridSimulationConfig,
+                 R_major: float = 0.6,
+                 R_minor: float = 0.3,
+                 tesseract_scale: float = 0.35,
+                 R0: float = 1.0) -> None:
+        self.config = config
+        self.sutra_context = SutraContext(
+            mode=config.sutra_mode,
+            base=config.sutra_base,
+            parallel=config.execution_mode != "serial",
+        )
+        self.sutra_plan = SutraExecutionPlan(
+            context=self.sutra_context,
+            execution_mode=config.execution_mode,
+            max_workers=config.max_workers,
+        )
+        self.system = GRVQToroidalHypercube(
+            R_major=R_major,
+            R_minor=R_minor,
+            tesseract_scale=tesseract_scale,
+            R0=R0,
+            sutra_plan=self.sutra_plan,
+        )
+
+    def _run_with_mode(self, execution_mode: str) -> Dict[str, Any]:
+        local_plan = SutraExecutionPlan(
+            context=self.sutra_context,
+            execution_mode=execution_mode,
+            max_workers=self.config.max_workers,
+        )
+        result = self.system.compute_full_system(
+            n_points=self.config.n_points,
+            m=self.config.m_mode,
+            n=self.config.n_mode,
+            angle_xw=self.config.angle_xw,
+            sutra_plan=local_plan,
+        )
+        result["sutra_execution_mode"] = execution_mode
+        result["sutra_mode"] = self.sutra_context.mode.name
+        result["sutra_base"] = self.sutra_context.base
+        result["field_energy"] = float(np.linalg.norm(result["transformed_field"]))
+        result["field_mean"] = float(np.mean(result["transformed_field"]))
+        result["sutra_plan"] = local_plan
+        return result
+
+    def run_serial(self) -> Dict[str, Any]:
+        """Run with serial sutra execution."""
+        return self._run_with_mode("serial")
+
+    def run_concurrent(self) -> Dict[str, Any]:
+        """Run with concurrent (threaded) sutra execution."""
+        return self._run_with_mode("concurrent")
+
+    def run_parallel(self) -> Dict[str, Any]:
+        """Run with parallel (process) sutra execution."""
+        return self._run_with_mode("parallel")
+
+    def run(self) -> Dict[str, Any]:
+        """Run using the configured execution mode."""
+        return self._run_with_mode(self.config.execution_mode)

--- a/primarysutra.py
+++ b/primarysutra.py
@@ -162,14 +162,8 @@ class VedicSutras:
         """
         self.context = context if context else SutraContext()
         
-        # Initialize GPU if requested
-        if TORCH_AVAILABLE and self.context.use_gpu and getattr(torch, 'cuda', None) and torch.cuda.is_available():
         # Initialize GPU if requested and available
-        if (
-            self.context.use_gpu
-            and torch is not None
-            and torch.cuda.is_available()
-        ):
+        if self.context.use_gpu and torch is not None and torch.cuda.is_available():
             self.context.device = torch.device("cuda")
             logger.info(
                 f"Using GPU device: {torch.cuda.get_device_name(0)}"


### PR DESCRIPTION
### Motivation
- Provide selectable execution strategies (serial, threaded concurrent, and process-parallel) for the 29-sutra Vedic update stage to support hybrid quantum/classical simulation workflows.
- Integrate quantum-capable sutra coordination so hybrid simulations can optionally apply quantum-derived corrections when a quantum backend is available.
- Expose the execution plan to the top-level GRVQ toroidal hypercube pipeline and add a small, reusable simulator entrypoint for running experiments with different sutra execution modes.

### Description
- Add `SutraExecutionPlan` and `HybridSutraCoordinator` to `grvq_toroidal_hypercube.py` to encapsulate execution strategy and optionally apply a quantum-derived correction via `VedicSutras` APIs, guarded by `_quantum_available()`.
- Extend `VedicSutraEngine.apply_all_29_sutras` to accept `execution_mode` and implement three sub-sutra strategies: `apply_subsutras_serial` (sequential), `apply_subsutras_concurrent` (threaded), and `apply_subsutras_parallel` (process-based using `ProcessPoolExecutor`).
- Wire execution plan into `GRVQToroidalHypercube` by adding `sutra_plan` constructor parameter and using `HybridSutraCoordinator` in `apply_vedic_transformation` and `compute_full_system` to permit per-run control of sutra execution.
- Add `hybrid_grvq_toroidal_simulator.py` as a small orchestration layer with `HybridSimulationConfig` and `HybridGRVQToroidalSimulator` exposing `run_serial`, `run_concurrent`, and `run_parallel` conveniences.
- Import and logging cleanup: add `import primarysutra`, logger initialization, and small dataclass imports refinements in `grvq_toroidal_hypercube.py`.
- Fix GPU initialization logic in `primarysutra.py` by correcting the conditional and indentation for device selection to ensure deterministic CPU/GPU choice when `use_gpu` is requested.

### Testing
- No automated tests were run as part of this change (`none`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f986d8d848332b4f3c662cad3e760)