### PR TITLE
Upgrade toroid launcher for full hybrid platform orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,24 @@ concurrent, and parallel execution.
 
 Product and revenue details are documented in
 `docs/hybrid_sutra_platform.md`.
+
+## Toroid HTML Launcher
+
+Run the Toroid interface and the full 29-sutra hybrid platform (serial, concurrent,
+and parallel) with structured output artifacts:
+
+```bash
+python run_toroid_hybrid.py \
+  --toroid-path "toroid HTML" \
+  --value 1.0 \
+  --mode hybrid \
+  --hybrid-output runs/hybrid_sutra_platform_report.json \
+  --report-path runs/toroid_launcher_report.json
+```
+
+If your branch uses `toroid_HTML`, the launcher auto-detects it. To serve only the
+front-end artifact without launching the simulator:
+
+```bash
+python run_toroid_hybrid.py --skip-hybrid --port 8000
+```

--- a/hybrid_simulator.py
+++ b/hybrid_simulator.py
@@ -7,20 +7,21 @@ in serial, concurrent, and parallel modes with FM8-style audio control.
 from __future__ import annotations
 
 import argparse
-import math
+import json
 import os
 import sys
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from dataclasses import dataclass
+from statistics import mean
 from typing import Any, Dict, List, Sequence, Tuple
 
-import numpy as np
+try:
+    import numpy as np
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    np = None
 
-from hc_ipc import HcIpcClient
-from hypercube_fm8 import HyperCubeFM8
 from qiskit_backend import execute_ghz
 from sutra_repository import SutraContext, SutraMode, SutraRepository
-
 
 PREFERRED_SUTRAS = [
     "ekadhikena_purvena",
@@ -119,12 +120,12 @@ def _call_sutra_in_process(name: str, value: float, mode: SutraMode) -> Tuple[st
 def _to_scalar(value: Any) -> float:
     if isinstance(value, (int, float)):
         return float(value)
-    if isinstance(value, np.ndarray):
+    if np is not None and isinstance(value, np.ndarray):
         return float(np.mean(value))
     if isinstance(value, (list, tuple)):
         if len(value) == 0:
             return 0.0
-        return float(np.mean([_to_scalar(v) for v in value]))
+        return float(mean(_to_scalar(v) for v in value))
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -195,12 +196,7 @@ def run_parallel(value: float, mode: SutraMode, sutra_names: Sequence[str]) -> H
     return HybridRunSummary(mode="parallel", results=results, final_value=final_value)
 
 
-def apply_audio_updates(
-    cube: HyperCubeFM8,
-    results: Sequence[SutraRunResult],
-    mix_mode: str,
-    ipc: HcIpcClient,
-) -> None:
+def apply_audio_updates(cube: Any, results: Sequence[SutraRunResult], mix_mode: str, ipc: Any) -> None:
     for result in results:
         cube.apply_sutra_to_operators(result.name, [_to_scalar(result.output)])
     cube.set_mix_mode(mix_mode)
@@ -216,6 +212,14 @@ def apply_audio_updates(
     )
 
 
+def _summary_dict(summary: HybridRunSummary) -> Dict[str, Any]:
+    return {
+        "mode": summary.mode,
+        "final_value": summary.final_value,
+        "results": [{"name": r.name, "scalar_output": _to_scalar(r.output)} for r in summary.results],
+    }
+
+
 def main(argv: Sequence[str]) -> int:
     parser = argparse.ArgumentParser(description="Hybrid sutra simulator")
     parser.add_argument("value", type=float, help="Base input value")
@@ -227,15 +231,29 @@ def main(argv: Sequence[str]) -> int:
     )
     parser.add_argument("--run-all-modes", action="store_true", help="Run serial+concurrent+parallel")
     parser.add_argument("--enable-audio", action="store_true", help="Send audio updates")
+    parser.add_argument("--sutra-count", type=int, default=29, help="Number of sutras to execute")
+    parser.add_argument(
+        "--report-path",
+        default="runs/hybrid_run_report.json",
+        help="Optional output JSON report path",
+    )
     args = parser.parse_args(argv)
 
     mode = SutraMode[args.mode.upper()]
     repo = SutraRepository(SutraContext(mode=mode))
-    sutra_names = select_sutra_names(repo)
+    sutra_names = select_sutra_names(repo, target_count=args.sutra_count)
+    if len(sutra_names) < args.sutra_count:
+        raise RuntimeError(f"Requested {args.sutra_count} sutras but found {len(sutra_names)}")
 
     audio_enabled = args.enable_audio or os.getenv("QUANQONSCIOUS_AUDIO", "0") == "1"
-    ipc = HcIpcClient() if audio_enabled else None
-    cube = HyperCubeFM8(num_ops=12, base_frequency=432.0)
+    ipc = None
+    cube = None
+    if audio_enabled:
+        from hc_ipc import HcIpcClient
+        from hypercube_fm8 import HyperCubeFM8
+
+        ipc = HcIpcClient()
+        cube = HyperCubeFM8(num_ops=12, base_frequency=432.0)
 
     run_modes = ["serial", "concurrent", "parallel"] if args.run_all_modes else ["serial"]
 
@@ -257,6 +275,18 @@ def main(argv: Sequence[str]) -> int:
         for result in summary.results:
             scalar = _to_scalar(result.output)
             print(f"  {result.name}: {scalar:.6f}")
+
+    os.makedirs(os.path.dirname(args.report_path), exist_ok=True)
+    report_payload = {
+        "input_value": args.value,
+        "mode": args.mode,
+        "sutra_count": args.sutra_count,
+        "run_modes": run_modes,
+        "summaries": [_summary_dict(summary) for summary in summaries],
+    }
+    with open(args.report_path, "w", encoding="utf-8") as f:
+        json.dump(report_payload, f, indent=2)
+    print(f"\nReport written to {args.report_path}")
 
     return 0
 

--- a/qiskit_backend.py
+++ b/qiskit_backend.py
@@ -4,33 +4,44 @@ This module provides a gateway to IBM's Qiskit framework beyond trivial
 examples, allowing the QuanQonscious platform to orchestrate multi-qubit
 experiments that mirror the concurrent execution of the 29 Vedic sutras.
 
-The primary entry point is :func:`execute_ghz`, which constructs a GHZ
-(Greenberger–Horne–Zeilinger) state across an arbitrary number of qubits.
-In the default configuration we entangle 29 qubits, mapping one-to-one with
-our sutra set to emphasize simultaneous coherence.  The circuit is fully
-transpiled and executed using the Qiskit Aer simulator, returning
-measurement counts suitable for downstream classical-quantum fusion.
+When Qiskit is unavailable in the execution environment, the module falls
+back to a deterministic GHZ-like count distribution so the rest of the
+hybrid pipeline remains runnable.
 """
 
 from __future__ import annotations
 
 from typing import Dict
 
-from qiskit import QuantumCircuit, transpile
-from qiskit_aer import AerSimulator
-from qiskit.result import Counts
+try:
+    from qiskit import QuantumCircuit, transpile
+    from qiskit_aer import AerSimulator
+    from qiskit.result import Counts
+    QISKIT_AVAILABLE = True
+except ModuleNotFoundError:
+    QuantumCircuit = None  # type: ignore[assignment]
+    transpile = None  # type: ignore[assignment]
+    AerSimulator = None  # type: ignore[assignment]
+    Counts = Dict[str, int]  # type: ignore[misc,assignment]
+    QISKIT_AVAILABLE = False
+
+
+def _fallback_ghz_counts(num_qubits: int, shots: int) -> Dict[str, int]:
+    """Generate deterministic GHZ-style counts without Qiskit.
+
+    The ideal GHZ state over ``num_qubits`` measures as all-zeros or all-ones.
+    We split shots as evenly as possible to preserve that structure.
+    """
+
+    zeros = "0" * num_qubits
+    ones = "1" * num_qubits
+    high = shots // 2
+    low = shots - high
+    return {zeros: high, ones: low}
 
 
 def execute_ghz(num_qubits: int = 29, shots: int = 1024) -> Counts:
     """Create and measure a GHZ state on ``num_qubits`` qubits.
-
-    The procedure follows established Qiskit documentation for GHZ-state
-    preparation:
-
-    1. Apply a Hadamard gate to the first qubit to create superposition.
-    2. Cascade ``CX`` gates from the first qubit to all others to generate a
-       maximally entangled GHZ state.
-    3. Measure each qubit in the computational basis.
 
     Parameters
     ----------
@@ -48,6 +59,11 @@ def execute_ghz(num_qubits: int = 29, shots: int = 1024) -> Counts:
 
     if num_qubits < 1:
         raise ValueError("num_qubits must be positive")
+    if shots < 1:
+        raise ValueError("shots must be positive")
+
+    if not QISKIT_AVAILABLE:
+        return _fallback_ghz_counts(num_qubits, shots)
 
     circuit = QuantumCircuit(num_qubits, num_qubits, name="ghz")
     circuit.h(0)

--- a/run_toroid_hybrid.py
+++ b/run_toroid_hybrid.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Production launcher for Toroid UI + 29-sutra hybrid simulator.
+
+This runner is designed for full workflow execution:
+1. Resolve and serve the toroid HTML artifact.
+2. Verify HTTP availability.
+3. Execute 29-sutra hybrid simulator in serial, concurrent, and parallel lanes.
+4. Persist stdout/stderr logs and structured report paths for auditability.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.server
+import importlib.util
+import json
+import socketserver
+import subprocess
+import sys
+import threading
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+DEFAULT_TOROID_CANDIDATES = [
+    "toroid_HTML",
+    "toroid HTML",
+]
+
+
+@dataclass
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    command: List[str]
+
+
+def _module_available(name: str) -> bool:
+    return importlib.util.find_spec(name) is not None
+
+
+def check_runtime_dependencies() -> Dict[str, bool]:
+    return {
+        "numpy": _module_available("numpy"),
+        "scipy": _module_available("scipy"),
+        "pandas": _module_available("pandas"),
+        "sympy": _module_available("sympy"),
+        "torch": _module_available("torch"),
+        "qiskit": _module_available("qiskit"),
+    }
+
+
+def resolve_toroid_path(explicit_path: Optional[str]) -> Path:
+    if explicit_path:
+        candidate = Path(explicit_path)
+        if candidate.exists():
+            return candidate
+        raise FileNotFoundError(f"Provided toroid path does not exist: {candidate}")
+
+    for name in DEFAULT_TOROID_CANDIDATES:
+        candidate = Path(name)
+        if candidate.exists():
+            return candidate
+
+    raise FileNotFoundError(
+        "Could not locate toroid file. Tried: " + ", ".join(DEFAULT_TOROID_CANDIDATES)
+    )
+
+
+def run_server(host: str, port: int) -> socketserver.TCPServer:
+    handler = http.server.SimpleHTTPRequestHandler
+    httpd = socketserver.TCPServer((host, port), handler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    return httpd
+
+
+def verify_http(url: str, timeout_s: float) -> bool:
+    try:
+        request = urllib.request.Request(url, method="HEAD")
+        with urllib.request.urlopen(request, timeout=timeout_s) as resp:
+            return 200 <= resp.status < 400
+    except Exception:
+        return False
+
+
+def run_command(command: List[str]) -> CommandResult:
+    completed = subprocess.run(command, text=True, capture_output=True)
+    return CommandResult(
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+        command=command,
+    )
+
+
+def build_hybrid_command(
+    value: float,
+    mode: str,
+    output_path: Path,
+    max_workers: Optional[int],
+) -> List[str]:
+    command = [
+        sys.executable,
+        "hybrid_sutra_platform.py",
+        str(value),
+        "--mode",
+        mode,
+        "--output",
+        str(output_path),
+    ]
+    if max_workers is not None:
+        command.extend(["--max-workers", str(max_workers)])
+    return command
+
+
+def write_launcher_report(path: Path, payload: Dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description="Launch Toroid HTML and the 29-sutra hybrid simulator")
+    parser.add_argument("--host", default="127.0.0.1", help="HTTP host")
+    parser.add_argument("--port", type=int, default=8000, help="HTTP port")
+    parser.add_argument("--toroid-path", help="Explicit path to toroid HTML artifact")
+    parser.add_argument("--skip-hybrid", action="store_true", help="Only serve Toroid UI")
+    parser.add_argument("--value", type=float, default=1.0, help="Input value for hybrid simulator")
+    parser.add_argument("--mode", default="hybrid", help="Simulator mode")
+    parser.add_argument("--max-workers", type=int, help="Optional max workers for concurrent and parallel lanes")
+    parser.add_argument("--duration", type=float, default=10.0, help="Server lifetime in seconds")
+    parser.add_argument(
+        "--report-path",
+        default="runs/toroid_launcher_report.json",
+        help="Launcher report output path",
+    )
+    parser.add_argument(
+        "--hybrid-output",
+        default="runs/hybrid_sutra_platform_report.json",
+        help="Hybrid simulator JSON output path",
+    )
+    args = parser.parse_args(argv)
+
+    dependencies = check_runtime_dependencies()
+    toroid_file = resolve_toroid_path(args.toroid_path)
+
+    server = run_server(args.host, args.port)
+    encoded_path = urllib.parse.quote(toroid_file.name)
+    url = f"http://{args.host}:{args.port}/{encoded_path}"
+    http_ok = verify_http(url, timeout_s=2.0)
+    print(f"Toroid HTML URL: {url}")
+    print(f"HTTP verification: {'OK' if http_ok else 'FAILED'}")
+
+    hybrid_result: Optional[CommandResult] = None
+    if not args.skip_hybrid:
+        hybrid_output_path = Path(args.hybrid_output)
+        hybrid_output_path.parent.mkdir(parents=True, exist_ok=True)
+        command = build_hybrid_command(args.value, args.mode, hybrid_output_path, args.max_workers)
+        print("Executing hybrid command:", " ".join(command))
+        hybrid_result = run_command(command)
+        if hybrid_result.stdout:
+            print(hybrid_result.stdout)
+        if hybrid_result.stderr:
+            print(hybrid_result.stderr, file=sys.stderr)
+
+    report_payload: Dict[str, object] = {
+        "toroid_file": str(toroid_file),
+        "url": url,
+        "http_ok": http_ok,
+        "dependencies": dependencies,
+        "hybrid_executed": not args.skip_hybrid,
+        "hybrid_success": hybrid_result.returncode == 0 if hybrid_result else None,
+        "hybrid_command": hybrid_result.command if hybrid_result else None,
+        "hybrid_stdout": hybrid_result.stdout if hybrid_result else None,
+        "hybrid_stderr": hybrid_result.stderr if hybrid_result else None,
+    }
+    write_launcher_report(Path(args.report_path), report_payload)
+    print(f"Launcher report written to {args.report_path}")
+
+    time.sleep(max(args.duration, 0.0))
+    server.shutdown()
+    server.server_close()
+
+    if hybrid_result is not None and hybrid_result.returncode != 0:
+        return hybrid_result.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
### Motivation

- Provide a production-grade launcher to serve the repository's Toroid front-end and optionally run the full 29-sutra hybrid simulator end-to-end.  
- Make core hybrid pieces tolerant of missing/optional dependencies and avoid hard failures so the front-end and pipeline remain usable in constrained environments.  
- Emit structured, auditable run artifacts (launcher+simulator reports and logs) so runs can be validated and replayed.

### Description

- Added `run_toroid_hybrid.py`, a launcher that auto-resolves `toroid_HTML` / `toroid HTML`, serves the file over HTTP, verifies reachability via `HEAD`, optionally executes the hybrid simulator (`hybrid_sutra_platform.py`), and writes a structured launcher report (`--report-path`).  
- Hardened the hybrid stack: updated `hybrid_simulator.py` to import `numpy` optionally, use `statistics.mean` fallbacks, lazily import audio-only dependencies (`hc_ipc` / `hypercube_fm8`) when audio is enabled, add `--sutra-count` and `--report-path` CLI options, and write a JSON run report.  
- Made `qiskit_backend.py` tolerant of missing Qiskit by adding a `QISKIT_AVAILABLE` guard and a deterministic `_fallback_ghz_counts` used when Qiskit is unavailable, so downstream code can continue reproducibly.  
- Documentation: updated `README.md` with concrete usage examples for the Toroid launcher and hybrid report output paths.  

### Testing

- `python -m py_compile run_toroid_hybrid.py hybrid_sutra_platform.py sutra_simulator.py qiskit_backend.py` — succeeded.  
- `python run_toroid_hybrid.py --skip-hybrid --duration 1 --port 8021 --toroid-path 'toroid HTML'` — server started, `HEAD` verification returned OK, and `runs/toroid_launcher_report.json` was written (succeeded).  
- `python run_toroid_hybrid.py --duration 1 --port 8022 --toroid-path 'toroid HTML' --value 1.0 --mode hybrid --hybrid-output runs/hybrid_sutra_platform_report.json` — launcher and HTTP serving succeeded but the hybrid simulator invocation exited due to missing `numpy` in the environment (expected in constrained container).  
- `curl -I -L 'https://github.com/12cymatics/quanqonscious/blob/codex/create-github-repository-for-pcfe-v3.0/toroid_HTML'` — network/proxy returned HTTP 403 in this environment (external fetch limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996bb48c8408332a7ef6b157822d2ea)