### PR TITLE
Add HSQCP report/bundle schema, benchmark protocol, signature-vault persistence, and CLI/runtime-scalar controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,10 @@ Static contract validation:
 ```bash
 python scripts/validate_hsqcp_contracts.py
 ```
+
+
+Export benchmark matrix and reproducibility manifest in one run:
+
+```bash
+python hybrid_sutra_platform.py 1 --mode hybrid --benchmark-seeds 1,1618/1000,2,31415926535/10000000000 --benchmark-matrix-output runs/benchmark_matrix.json --manifest-output runs/repro_manifest.json
+```

--- a/README.md
+++ b/README.md
@@ -28,3 +28,30 @@ concurrent, and parallel execution.
 
 Product and revenue details are documented in
 `docs/hybrid_sutra_platform.md`.
+
+
+## Exact Rational Runtime Usage
+
+Run the hybrid 29-sutra engine with exact rational input:
+
+```bash
+python hybrid_sutra_platform.py 1618/1000 --mode hybrid --output runs/hsqcp_report.json
+```
+
+Run deterministic benchmark seeds with signature-vault persistence:
+
+```bash
+python hybrid_sutra_platform.py 1 --mode hybrid --benchmark-seeds 1,1618/1000,2,31415926535/10000000000 --vault-dir runs/vault --run-label baseline
+```
+
+Audit persisted signature-vault integrity:
+
+```bash
+python hybrid_sutra_platform.py 1 --audit-vault runs/vault
+```
+
+Static contract validation:
+
+```bash
+python scripts/validate_hsqcp_contracts.py
+```

--- a/docs/formal_asset_register.md
+++ b/docs/formal_asset_register.md
@@ -1,0 +1,108 @@
+# Formal Asset Register: Hybrid Quantum-Classical 29-Sutra Platform
+
+## Scope and Objective
+This register isolates the commercial and technical asset base of the repository
+into explicit units that can be defended, benchmarked, licensed, and productized
+without collapsing doctrine into generic simulation framing.
+
+The guiding product surface for external packaging is:
+
+> **Deterministic 29-operator hybrid execution engine with serial, concurrent,
+> and parallel benchmarking plus structured report artifacts.**
+
+## Asset Register Table
+
+| Asset ID | Asset Name | Evidence (Repo/Branch) | Maturity | Uniqueness | Commercial Route | Primary Weaknesses | Priority |
+|---|---|---|---|---|---|---|---|
+| A1 | 29-Sutra Runtime Kernel | `sutra_simulator.py` (`HybridQuantumClassicalSimulator`, `run_serial`, `run_concurrent`, `run_parallel`) | High | High | Core runtime licensing, OEM embedding, SDK/API base | Dependency fragility in default environment; requires clearer packaging/install baseline | P0 |
+| A2 | Sutra Callable Corpus + Repository Semantics | `sutra_repository.py`, `primarysutra.py` (callable sutra inventory and invocation path) | Medium-High | High | Method IP core, deterministic transform library, enterprise private runtimes | Inconsistent doctrinal purity across implementations; mixed symbolic/numeric styles | P0 |
+| A3 | Tri-Modal Structured Reporting Layer | `SimulationReport` and `to_dict()` serialization in `sutra_simulator.py`; JSON output pattern in `hybrid_sutra_platform.py` | High | Medium-High | Benchmark artifacts, audit trails, certification bundles, regression baselines | Report schema governance/versioning not yet formalized | P0 |
+| A4 | Hybrid Platform Product Shell | `hybrid_sutra_platform.py`, `README.md`, `docs/hybrid_sutra_platform.md` | High | Medium | Product packaging, paid API, operator workflows, partner demos | Needs hardened dependency lock + reproducible deployment profile | P1 |
+| A5 | One-Click Operator Console Surface | `web_server.py` and platform documentation tie-in | Medium-High | Medium | Sales demos, onboarding, investor/partner evaluation workflows | Risk of demo drift unless tightly pinned to runtime invariants | P1 |
+| A6 | Argument Resolver and Execution Generality Layer | Argument resolver hooks and runtime argument adaptation in simulator/orchestration path | Medium | Medium-High | SDK ergonomics, integration portability, reduced bespoke wiring costs | Needs explicit conformance tests across full 29-sutra signature set | P1 |
+| A7 | Signature Vault Concept (Data Product Layer) | Product doctrine in `docs/hybrid_sutra_platform.md` plus structured execution bundles | Medium | High | Proprietary corpus licensing, anomaly detection baselines, comparative performance index | Requires persistent storage model, schema evolution policy, integrity controls | P1 |
+| A8 | GRVQ/TGCR Hybrid Bridge Modules | Branch/PR-linked hybrid simulation modules (PDE/FCI bridge implementations) | Medium | Medium-High | Applied vertical demos, premium research integrations, domain pilots | Float-heavy implementations dilute exact-symbolic differentiation | P2 |
+| A9 | Exposed Runtime Scalar Governance | PR history notes and runtime scalar surfacing patterns (attenuation/gating/rebuild controls) | Medium | Medium | Tunable enterprise profiles, auditable control planes, premium configuration support | Parameter semantics need canonical docs and calibration protocol | P2 |
+| A10 | Audio/FM/IPC Experimental Control Surfaces | PR history assets for multimodal controls and launcher integration | Low-Medium | Medium | Specialized interactive products, experiential control lanes | Peripheral to primary wedge; can distract from kernel commercialization | P3 |
+| A11 | Formula/Proof Archive Corpus | Text/PDF proof assets and formula documents under repo/docs | Medium | Medium-High | Whitepaper support, partner diligence, technical marketing collateral | Limited direct monetization without executable/provable tie-back | P3 |
+| A12 | Historical Chat/Design Memory Corpus | Historical narrative artifacts and design records | Low (direct) / High (extractive) | Low (direct) | Internal synthesis, roadmap mining, doctrine consistency checks | Not externally saleable in raw form; high curation overhead | P4 |
+
+## Asset Class Separation (Do Not Blur)
+
+### Core Doctrine Assets (Defining IP)
+- 29-sutra operator semantics and callable corpus.
+- Deterministic orchestration invariants across serial/concurrent/parallel modes.
+- GRVQ/MSTVQ/TGCR coupling principles and exact-law commitments.
+- Canonical aggregation and signature semantics.
+
+### Demonstration Assets (Exposure + Distribution)
+- Launchers, dashboards, web console, notebooks, and run wrappers.
+- PDE/FCI bridge modules and visualization surfaces.
+- Sales-facing reporting and benchmarking outputs.
+
+**Control rule:** demonstration assets must remain strictly subordinate to doctrine
+assets. Demo convenience is permitted only when it does not overwrite core
+identity, invariants, or symbolic-method claims.
+
+## Maturity Heatmap (Condensed)
+
+| Zone | Definition | Current Items |
+|---|---|---|
+| Green | Production-near and externally packageable | A1, A3, A4 |
+| Yellow | Valuable but requiring hardening/specification | A2, A5, A6, A7, A8, A9 |
+| Orange | Supportive but non-core for near-term revenue wedge | A10, A11 |
+| Gray | Internal extraction value only | A12 |
+
+## Commercialization Wedge (Narrow External Surface)
+
+Primary external wedge should be constrained to:
+1. Deterministic 29-operator execution engine.
+2. Tri-modal benchmarking (serial/concurrent/parallel).
+3. Structured signature bundle output (machine-parseable artifact).
+
+Secondary expansions (post-wedge):
+- Hosted API metering,
+- Enterprise benchmark certification,
+- Domain-specific hybrid bridge integrations.
+
+## Defensibility Upgrades Required
+
+1. **Schema formalization:** versioned report/signature schema with compatibility
+   guarantees and migration policy.
+2. **Runtime reproducibility:** pinned dependencies, environment lockfiles,
+   deterministic run recipe, and baseline CI execution checks.
+3. **Doctrine fidelity tags:** explicitly label modules as `exact-symbolic core`,
+   `hybrid bridge`, or `demo adapter` to prevent conceptual drift.
+4. **Parameter governance:** canonical scalar registry with documented ranges,
+   sensitivity notes, and audit trails.
+5. **Benchmark protocol:** fixed corpus of seed inputs and mode comparisons for
+   repeatable external claims.
+
+## Priority Execution Plan
+
+### P0 (Immediate)
+- Preserve and harden A1/A2/A3 as canonical nucleus.
+- Freeze artifact semantics for tri-modal report bundles.
+- Publish minimal runtime contract for invoking all 29 sutras across three modes.
+
+### P1 (Near-Term)
+- Lock deployment reproducibility for platform shell + console.
+- Add conformance tests for argument resolver against full sutra inventory.
+- Begin persistent signature vault implementation with schema versioning.
+
+### P2 (Selective)
+- Refactor bridge modules to isolate numerical approximations from doctrine core.
+- Expose runtime scalars via explicit config contracts.
+
+### P3/P4 (Deferred)
+- Keep multimodal controls and archives as optional support lanes, not primary
+  product claims.
+
+## Bottom-Line Position
+The repository already contains an inspectable computational nucleus with real
+commercial potential: a deterministic 29-sutra hybrid runtime with tri-modal
+execution and structured outputs. Value is strongest where doctrine is encoded
+as repeatable software behavior and weakest where implementation drift obscures
+core identity. The highest-leverage path is not adding more conceptual breadth,
+but enforcing clear asset boundaries and shipping a narrow, defensible product
+surface first.

--- a/docs/hsqcp_benchmark_protocol.md
+++ b/docs/hsqcp_benchmark_protocol.md
@@ -49,3 +49,13 @@ This enables longitudinal regression checks and partner-facing audit trails.
 Use `hybrid_sutra_platform.py` with `--benchmark-seeds` and optional `--vault-dir`
 to execute and persist a complete tri-modal benchmark suite with explicit scalar
 settings and indexed artifacts.
+
+
+## Benchmark Matrix Artifact
+For benchmark suites, export a matrix JSON containing per-seed serial/concurrent/parallel
+wall-time nanoseconds and aggregate outputs. This artifact supports deterministic
+performance comparison and regression checks across seed corpora.
+
+## Reproducibility Manifest
+Export a manifest JSON containing runtime environment, scalar governance settings,
+seed list, and sutra inventory hash to guarantee audit-grade replayability.

--- a/docs/hsqcp_benchmark_protocol.md
+++ b/docs/hsqcp_benchmark_protocol.md
@@ -1,0 +1,51 @@
+# HSQCP Benchmark Protocol (v1)
+
+Protocol ID: `hsqcp.benchmark.v1`
+
+## Objective
+Provide a deterministic, reproducible benchmark procedure for comparing serial,
+concurrent, and parallel execution over the same sutra inventory and input
+payloads.
+
+## Canonical Procedure
+1. Select a fixed input seed set (scalars or structured payloads).
+2. For each seed, run all sutras in:
+   - serial mode,
+   - concurrent mode,
+   - parallel mode.
+3. Capture full bundle output with schema versions intact.
+4. Compute per-mode summary statistics:
+   - wall time,
+   - execution count,
+   - aggregate output consistency checks.
+5. Persist bundle artifacts to a signature vault index.
+6. Record runtime scalar governance values with each bundle (`grvq_beta_scale`, `grvq_gamma_scale`,
+   `engine_rebuild_interval`, `engine_drift_threshold`).
+7. Record runtime environment provenance (python version, platform, commit hash).
+
+## Required Invariants
+- Same sutra inventory for all three modes per run.
+- Stable schema markers (`hsqcp.bundle.v1`, `hsqcp.report.v1`).
+- Explicit doctrine fidelity tag per report.
+- No placeholder or pseudo execution paths.
+
+## Recommended Baseline Seed Set (Exact Rationals)
+- 1
+- 1618/1000
+- 2
+- 31415926535/10000000000
+
+## Storage Guidance
+Persist artifacts as immutable JSON payloads keyed by:
+- benchmark protocol version,
+- runtime commit hash,
+- input seed,
+- execution timestamp.
+
+This enables longitudinal regression checks and partner-facing audit trails.
+
+
+## CLI Execution Pattern
+Use `hybrid_sutra_platform.py` with `--benchmark-seeds` and optional `--vault-dir`
+to execute and persist a complete tri-modal benchmark suite with explicit scalar
+settings and indexed artifacts.

--- a/docs/hsqcp_benchmark_protocol.md
+++ b/docs/hsqcp_benchmark_protocol.md
@@ -59,3 +59,8 @@ performance comparison and regression checks across seed corpora.
 ## Reproducibility Manifest
 Export a manifest JSON containing runtime environment, scalar governance settings,
 seed list, and sutra inventory hash to guarantee audit-grade replayability.
+
+
+## Benchmark Set Consistency
+A benchmark suite is valid only if all bundles share the same sutra inventory
+hash; mixed inventories are rejected to preserve comparability across seeds.

--- a/docs/hsqcp_report_schema.md
+++ b/docs/hsqcp_report_schema.md
@@ -1,0 +1,73 @@
+# HSQCP Report and Bundle Schema (v1)
+
+## Purpose
+This document defines the stable machine-readable artifact contract emitted by
+`hybrid_sutra_platform.py` and `sutra_simulator.py` for the deterministic
+29-sutra hybrid quantum-classical runtime.
+
+## Doctrine Fidelity Classification
+- `exact-symbolic-core`: canonical doctrine-level execution and report payloads.
+- `hybrid-bridge`: numerical or bridge modules that remain integrated but are
+  not classified as exact-symbolic core.
+- `demo-adapter`: UI/reporting wrappers that do not define runtime semantics.
+
+The current simulator and bundle payloads emit `exact-symbolic-core` as the
+required doctrine fidelity marker.
+
+## Bundle Schema
+Top-level version: `hsqcp.bundle.v1`
+
+Required fields:
+- `schema_version` (string)
+- `report_schema_version` (string)
+- `benchmark_protocol_version` (string)
+- `doctrine_fidelity` (string)
+- `generated_at_utc` (RFC3339 timestamp string)
+- `initial_value` (exact rational or structured value)
+- `sutra_names` (array of strings)
+- `runtime_scalars` (object containing scalar governance controls)
+- `runtime_environment` (object with python/platform/commit provenance)
+- `serial` (SimulationReport)
+- `concurrent` (SimulationReport)
+- `parallel` (SimulationReport)
+
+## SimulationReport Schema
+Report version: `hsqcp.report.v1`
+
+Required fields:
+- `schema_version` (string)
+- `doctrine_fidelity` (string)
+- `generated_at_utc` (RFC3339 timestamp string)
+- `mode` (string; one of `CLASSICAL|QUANTUM|HYBRID|...` enum names)
+- `initial_value` (exact rational or structured value)
+- `aggregate` (mode-specific aggregate output)
+- `wall_time_ns` (integer nanoseconds)
+- `executions` (array of execution records)
+
+Execution record fields:
+- `name` (sutra function name)
+- `elapsed_ns` (integer nanoseconds)
+- `output` (sutra output payload)
+
+## Compatibility Policy
+- **Minor, backward-compatible extensions:** add optional fields only.
+- **Breaking changes:** bump `hsqcp.bundle.vN` and `hsqcp.report.vN` in lockstep.
+- **Validation gate:** any bundle writer must run schema invariant checks before
+  persisting artifacts.
+
+
+## Signature Vault Index Contract
+When persisted with the platform vault writer, each bundle emits an `index.jsonl` entry containing:
+- `bundle_id` (sha256 of canonicalized payload),
+- `run_label`,
+- `benchmark_protocol_version`,
+- `report_schema_version`,
+- `generated_at_utc`,
+- `path` (bundle filename),
+- `sutra_count`,
+- `initial_value`.
+
+
+## Vault Audit
+Use `hybrid_sutra_platform.py --audit-vault <path>` to validate that each indexed
+bundle exists, passes schema validation, and matches its canonical payload hash.

--- a/docs/hsqcp_report_schema.md
+++ b/docs/hsqcp_report_schema.md
@@ -71,3 +71,13 @@ When persisted with the platform vault writer, each bundle emits an `index.jsonl
 ## Vault Audit
 Use `hybrid_sutra_platform.py --audit-vault <path>` to validate that each indexed
 bundle exists, passes schema validation, and matches its canonical payload hash.
+
+
+## Reproducibility Manifest Fields
+When generated, manifest payloads include:
+- `sutra_inventory_hash` (sha256 over sorted sutra names),
+- `runtime_scalars`,
+- `runtime_environment`,
+- `seeds`,
+- `seed_count`,
+- version and doctrine markers aligned with bundle/report schemas.

--- a/docs/hsqcp_report_schema.md
+++ b/docs/hsqcp_report_schema.md
@@ -65,7 +65,8 @@ When persisted with the platform vault writer, each bundle emits an `index.jsonl
 - `generated_at_utc`,
 - `path` (bundle filename),
 - `sutra_count`,
-- `initial_value`.
+- `initial_value`,
+- `sutra_inventory_hash` (sha256 over bundle sutra inventory).
 
 
 ## Vault Audit
@@ -81,3 +82,9 @@ When generated, manifest payloads include:
 - `seeds`,
 - `seed_count`,
 - version and doctrine markers aligned with bundle/report schemas.
+
+
+## Semantic Validation Rules
+Bundle validation enforces that each serial/concurrent/parallel report uses the
+report schema marker, doctrine fidelity marker, execution count equal to sutra
+inventory length, and execution-name set equality against `sutra_names`.

--- a/hybrid_sutra_platform.py
+++ b/hybrid_sutra_platform.py
@@ -10,21 +10,84 @@ integration with external services.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import platform
+import subprocess
+import sys
 from dataclasses import dataclass
+from fractions import Fraction
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Set
 
-from sutra_simulator import HybridQuantumClassicalSimulator, SimulationReport
-from sutra_repository import SutraContext, SutraMode
+from sutra_simulator import (
+    DOCTRINE_FIDELITY_TAG,
+    REPORT_SCHEMA_VERSION,
+    HybridQuantumClassicalSimulator,
+    SimulationReport,
+)
+from sutra_repository import SutraContext, SutraMode, SutraRepository
+
+BUNDLE_SCHEMA_VERSION = "hsqcp.bundle.v1"
+BENCHMARK_PROTOCOL_VERSION = "hsqcp.benchmark.v1"
+DEFAULT_BENCHMARK_SEEDS = ("1", "1618/1000", "2", "31415926535/10000000000")
 
 
-@dataclass
-class ModeRunConfig:
-    """Configuration for a single simulator execution mode."""
+def _resolve_git_commit() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return "unknown"
 
-    label: str
-    mode: SutraMode
+
+def runtime_environment_metadata() -> Dict[str, Any]:
+    return {
+        "python_version": sys.version.split()[0],
+        "platform": platform.platform(),
+        "git_commit": _resolve_git_commit(),
+    }
+
+
+def parse_exact_rational(raw: str) -> Fraction:
+    value = raw.strip()
+    if not value:
+        raise ValueError("Empty rational value is not allowed")
+    return Fraction(value)
+
+
+@dataclass(frozen=True)
+class RuntimeScalarConfig:
+    """Explicit scalar governance configuration for runtime execution."""
+
+    grvq_beta_scale: Fraction = Fraction(1, 1)
+    grvq_gamma_scale: Fraction = Fraction(1, 1)
+    engine_rebuild_interval: int = 64
+    engine_drift_threshold: Fraction = Fraction(1, 1_000_000)
+
+    def __post_init__(self) -> None:
+        if self.grvq_beta_scale <= 0:
+            raise ValueError("grvq_beta_scale must be > 0")
+        if self.grvq_gamma_scale <= 0:
+            raise ValueError("grvq_gamma_scale must be > 0")
+        if self.engine_rebuild_interval <= 0:
+            raise ValueError("engine_rebuild_interval must be > 0")
+        if self.engine_drift_threshold <= 0:
+            raise ValueError("engine_drift_threshold must be > 0")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "grvq_beta_scale": str(self.grvq_beta_scale),
+            "grvq_gamma_scale": str(self.grvq_gamma_scale),
+            "engine_rebuild_interval": self.engine_rebuild_interval,
+            "engine_drift_threshold": str(self.engine_drift_threshold),
+        }
 
 
 @dataclass
@@ -36,15 +99,73 @@ class HybridSimulationBundle:
     serial: SimulationReport
     concurrent: SimulationReport
     parallel: SimulationReport
+    runtime_scalars: RuntimeScalarConfig
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        payload = {
+            "schema_version": BUNDLE_SCHEMA_VERSION,
+            "report_schema_version": REPORT_SCHEMA_VERSION,
+            "benchmark_protocol_version": BENCHMARK_PROTOCOL_VERSION,
+            "doctrine_fidelity": DOCTRINE_FIDELITY_TAG,
+            "generated_at_utc": datetime.now(timezone.utc).isoformat(),
             "initial_value": self.initial_value,
             "sutra_names": list(self.sutra_names),
+            "runtime_scalars": self.runtime_scalars.to_dict(),
+            "runtime_environment": runtime_environment_metadata(),
             "serial": self.serial.to_dict(),
             "concurrent": self.concurrent.to_dict(),
             "parallel": self.parallel.to_dict(),
         }
+        validate_bundle_payload(payload)
+        return payload
+
+
+@dataclass
+class PersistedBundle:
+    bundle_id: str
+    path: Path
+
+
+def validate_bundle_payload(payload: Dict[str, Any]) -> None:
+    """Validate top-level bundle schema invariants for stable artifacts."""
+
+    required = (
+        "schema_version",
+        "report_schema_version",
+        "benchmark_protocol_version",
+        "doctrine_fidelity",
+        "generated_at_utc",
+        "initial_value",
+        "sutra_names",
+        "runtime_scalars",
+        "runtime_environment",
+        "serial",
+        "concurrent",
+        "parallel",
+    )
+    for key in required:
+        if key not in payload:
+            raise ValueError(f"Missing required bundle field: {key}")
+
+    if payload["schema_version"] != BUNDLE_SCHEMA_VERSION:
+        raise ValueError(
+            f"Unexpected bundle schema version: {payload['schema_version']}"
+        )
+    if payload["report_schema_version"] != REPORT_SCHEMA_VERSION:
+        raise ValueError(
+            f"Unexpected report schema version: {payload['report_schema_version']}"
+        )
+    if payload["benchmark_protocol_version"] != BENCHMARK_PROTOCOL_VERSION:
+        raise ValueError(
+            "Unexpected benchmark protocol version: "
+            f"{payload['benchmark_protocol_version']}"
+        )
+    if payload["doctrine_fidelity"] != DOCTRINE_FIDELITY_TAG:
+        raise ValueError(
+            f"Unexpected doctrine fidelity tag: {payload['doctrine_fidelity']}"
+        )
+    if len(payload["sutra_names"]) == 0:
+        raise ValueError("Bundle must contain at least one sutra")
 
 
 def _parse_mode(value: str) -> SutraMode:
@@ -55,19 +176,36 @@ def _parse_mode(value: str) -> SutraMode:
         raise ValueError(f"Unknown mode '{value}'. Options: {options}") from exc
 
 
-def _build_context(mode: SutraMode, *, precision: int, max_iterations: int) -> SutraContext:
-    return SutraContext(
+def _build_context(
+    mode: SutraMode,
+    *,
+    precision: int,
+    max_iterations: int,
+    runtime_scalars: RuntimeScalarConfig,
+) -> SutraContext:
+    context = SutraContext(
         mode=mode,
         precision=precision,
         max_iterations=max_iterations,
         parallel=True,
     )
+    setattr(context, "grvq_beta_scale", runtime_scalars.grvq_beta_scale)
+    setattr(context, "grvq_gamma_scale", runtime_scalars.grvq_gamma_scale)
+    setattr(context, "engine_rebuild_interval", runtime_scalars.engine_rebuild_interval)
+    setattr(context, "engine_drift_threshold", runtime_scalars.engine_drift_threshold)
+    return context
 
 
 def _apply_filter(names: Iterable[str], *, include: Optional[str]) -> List[str]:
     if include is None:
         return list(names)
-    return [name for name in names if include.lower() in name.lower()]
+    lowered = include.lower()
+    return [name for name in names if lowered in name.lower()]
+
+
+def compute_bundle_id(payload: Dict[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 def run_hybrid_bundle(
@@ -76,19 +214,31 @@ def run_hybrid_bundle(
     mode: SutraMode,
     precision: int,
     max_iterations: int,
+    runtime_scalars: Optional[RuntimeScalarConfig] = None,
     include: Optional[str] = None,
     max_workers: Optional[int] = None,
 ) -> HybridSimulationBundle:
     """Run serial, concurrent, and parallel suites for the full sutra set."""
 
-    context = _build_context(mode, precision=precision, max_iterations=max_iterations)
-    simulator = HybridQuantumClassicalSimulator(context=context, max_workers=max_workers)
+    scalar_config = runtime_scalars or RuntimeScalarConfig()
+    context = _build_context(
+        mode,
+        precision=precision,
+        max_iterations=max_iterations,
+        runtime_scalars=scalar_config,
+    )
+    name_filter = None
     if include:
-        simulator = HybridQuantumClassicalSimulator(
-            context=context,
-            max_workers=max_workers,
-            sutra_filter=lambda name: name in _apply_filter(simulator.sutra_names, include=include),
+        filtered_names: Set[str] = set(
+            _apply_filter(SutraRepository(context).list_sutras(), include=include)
         )
+        name_filter = lambda name: name in filtered_names
+
+    simulator = HybridQuantumClassicalSimulator(
+        context=context,
+        max_workers=max_workers,
+        sutra_filter=name_filter,
+    )
 
     sutra_names = list(simulator.sutra_names)
     serial_report = simulator.run_serial(value, mode=mode)
@@ -100,15 +250,117 @@ def run_hybrid_bundle(
         serial=serial_report,
         concurrent=concurrent_report,
         parallel=parallel_report,
+        runtime_scalars=scalar_config,
     )
+
+
+def run_benchmark_suite(
+    *,
+    mode: SutraMode,
+    precision: int,
+    max_iterations: int,
+    seeds: Iterable[Fraction] = tuple(parse_exact_rational(x) for x in DEFAULT_BENCHMARK_SEEDS),
+    runtime_scalars: Optional[RuntimeScalarConfig] = None,
+    include: Optional[str] = None,
+    max_workers: Optional[int] = None,
+) -> List[HybridSimulationBundle]:
+    bundles: List[HybridSimulationBundle] = []
+    for seed in seeds:
+        bundles.append(
+            run_hybrid_bundle(
+                seed,
+                mode=mode,
+                precision=precision,
+                max_iterations=max_iterations,
+                runtime_scalars=runtime_scalars,
+                include=include,
+                max_workers=max_workers,
+            )
+        )
+    return bundles
+
+
+def persist_signature_bundle(
+    bundle: HybridSimulationBundle,
+    vault_dir: Path,
+    *,
+    run_label: str,
+) -> PersistedBundle:
+    """Persist a validated bundle into a signature-vault directory."""
+
+    payload = bundle.to_dict()
+    bundle_id = compute_bundle_id(payload)
+
+    vault_dir.mkdir(parents=True, exist_ok=True)
+    bundle_path = vault_dir / f"{bundle_id}.json"
+    bundle_path.write_text(json.dumps(payload, indent=2))
+
+    index_entry = {
+        "bundle_id": bundle_id,
+        "run_label": run_label,
+        "benchmark_protocol_version": BENCHMARK_PROTOCOL_VERSION,
+        "report_schema_version": REPORT_SCHEMA_VERSION,
+        "generated_at_utc": payload["generated_at_utc"],
+        "path": str(bundle_path.name),
+        "sutra_count": len(payload["sutra_names"]),
+        "initial_value": payload["initial_value"],
+    }
+    index_path = vault_dir / "index.jsonl"
+    with index_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(index_entry) + "\n")
+
+    return PersistedBundle(bundle_id=bundle_id, path=bundle_path)
+
+
+def load_bundle_payload(path: Path) -> Dict[str, Any]:
+    payload = json.loads(path.read_text())
+    validate_bundle_payload(payload)
+    return payload
+
+
+def verify_bundle_file(path: Path) -> str:
+    payload = load_bundle_payload(path)
+    expected = compute_bundle_id(payload)
+    if path.stem != expected:
+        raise ValueError(
+            f"Bundle filename hash mismatch: file stem '{path.stem}' != computed '{expected}'"
+        )
+    return expected
+
+
+def audit_signature_vault(vault_dir: Path) -> Dict[str, Any]:
+    index_path = vault_dir / "index.jsonl"
+    if not index_path.exists():
+        raise FileNotFoundError(f"Signature vault index not found: {index_path}")
+
+    lines = [line for line in index_path.read_text().splitlines() if line.strip()]
+    checked = 0
+    for line in lines:
+        entry = json.loads(line)
+        bundle_path = vault_dir / entry["path"]
+        bundle_id = verify_bundle_file(bundle_path)
+        if entry["bundle_id"] != bundle_id:
+            raise ValueError(
+                f"Index bundle_id mismatch for {bundle_path.name}: "
+                f"index={entry['bundle_id']} computed={bundle_id}"
+            )
+        checked += 1
+
+    return {
+        "vault_dir": str(vault_dir),
+        "indexed_bundles": len(lines),
+        "verified_bundles": checked,
+    }
 
 
 def _summarize_report(report: SimulationReport) -> Dict[str, Any]:
     return {
         "mode": report.mode.name,
         "aggregate": report.aggregate,
-        "wall_time": report.wall_time,
+        "wall_time_ns": report.wall_time_ns,
         "sutra_count": len(report.executions),
+        "schema_version": report.schema_version,
+        "doctrine_fidelity": report.doctrine_fidelity,
     }
 
 
@@ -126,6 +378,13 @@ def write_report(bundle: HybridSimulationBundle, path: Path) -> None:
     path.write_text(json.dumps(payload, indent=2))
 
 
+def _parse_benchmark_seeds(raw: str) -> List[Fraction]:
+    values = [item.strip() for item in raw.split(",") if item.strip()]
+    if not values:
+        raise ValueError("--benchmark-seeds must contain at least one rational seed")
+    return [parse_exact_rational(item) for item in values]
+
+
 def build_cli() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
@@ -133,7 +392,7 @@ def build_cli() -> argparse.ArgumentParser:
             "for hybrid quantum-classical simulation workflows."
         )
     )
-    parser.add_argument("value", type=float, help="Input value to feed into sutras")
+    parser.add_argument("value", type=str, help="Input rational value to feed into sutras (e.g. 1618/1000)")
     parser.add_argument(
         "--mode",
         default="hybrid",
@@ -160,6 +419,29 @@ def build_cli() -> argparse.ArgumentParser:
         type=Path,
         help="Optional path to write the full JSON report",
     )
+    parser.add_argument(
+        "--vault-dir",
+        type=Path,
+        help="Optional signature-vault directory for indexed bundle persistence",
+    )
+    parser.add_argument(
+        "--run-label",
+        default="manual",
+        help="Run label recorded in signature-vault index entries",
+    )
+    parser.add_argument(
+        "--benchmark-seeds",
+        help="Comma-separated seed list to execute benchmark suite, e.g. 1.0,1.618,2.0",
+    )
+    parser.add_argument("--grvq-beta-scale", type=str, default="1")
+    parser.add_argument("--grvq-gamma-scale", type=str, default="1")
+    parser.add_argument("--engine-rebuild-interval", type=int, default=64)
+    parser.add_argument("--engine-drift-threshold", type=str, default="1/1000000")
+    parser.add_argument(
+        "--audit-vault",
+        type=Path,
+        help="Audit an existing signature vault and verify bundle/index integrity",
+    )
     return parser
 
 
@@ -167,12 +449,47 @@ def main() -> None:
     parser = build_cli()
     args = parser.parse_args()
 
+    if args.audit_vault:
+        audit = audit_signature_vault(args.audit_vault)
+        print(json.dumps(audit, indent=2))
+        return
+
     mode = _parse_mode(args.mode)
+    runtime_scalars = RuntimeScalarConfig(
+        grvq_beta_scale=parse_exact_rational(args.grvq_beta_scale),
+        grvq_gamma_scale=parse_exact_rational(args.grvq_gamma_scale),
+        engine_rebuild_interval=args.engine_rebuild_interval,
+        engine_drift_threshold=parse_exact_rational(args.engine_drift_threshold),
+    )
+
+    if args.benchmark_seeds:
+        seeds = _parse_benchmark_seeds(args.benchmark_seeds)
+        bundles = run_benchmark_suite(
+            mode=mode,
+            precision=args.precision,
+            max_iterations=args.max_iterations,
+            seeds=seeds,
+            runtime_scalars=runtime_scalars,
+            include=args.include,
+            max_workers=args.max_workers,
+        )
+        for bundle in bundles:
+            print_summary(bundle)
+            if args.vault_dir:
+                persisted = persist_signature_bundle(
+                    bundle,
+                    args.vault_dir,
+                    run_label=args.run_label,
+                )
+                print(f"Persisted bundle {persisted.bundle_id} -> {persisted.path}")
+        return
+
     bundle = run_hybrid_bundle(
-        args.value,
+        parse_exact_rational(args.value),
         mode=mode,
         precision=args.precision,
         max_iterations=args.max_iterations,
+        runtime_scalars=runtime_scalars,
         include=args.include,
         max_workers=args.max_workers,
     )
@@ -181,6 +498,14 @@ def main() -> None:
     if args.output:
         write_report(bundle, args.output)
         print(f"Report written to {args.output}")
+
+    if args.vault_dir:
+        persisted = persist_signature_bundle(
+            bundle,
+            args.vault_dir,
+            run_label=args.run_label,
+        )
+        print(f"Persisted bundle {persisted.bundle_id} -> {persisted.path}")
 
 
 if __name__ == "__main__":

--- a/hybrid_sutra_platform.py
+++ b/hybrid_sutra_platform.py
@@ -88,6 +88,7 @@ def write_benchmark_matrix(
     bundles: Sequence[HybridSimulationBundle],
     path: Path,
 ) -> None:
+    validate_benchmark_bundle_set(bundles)
     matrix = build_benchmark_matrix(bundles)
     path.write_text(json.dumps(matrix, indent=2))
 
@@ -96,8 +97,7 @@ def write_reproducibility_manifest(
     bundles: Sequence[HybridSimulationBundle],
     path: Path,
 ) -> None:
-    if not bundles:
-        raise ValueError("Cannot write manifest for empty benchmark bundle set")
+    validate_benchmark_bundle_set(bundles)
 
     first = bundles[0]
     manifest = {
@@ -227,6 +227,52 @@ def validate_bundle_payload(payload: Dict[str, Any]) -> None:
     if len(payload["sutra_names"]) == 0:
         raise ValueError("Bundle must contain at least one sutra")
 
+    validate_bundle_semantics(payload)
+
+
+
+def validate_bundle_semantics(payload: Dict[str, Any]) -> None:
+    sutra_names = list(payload["sutra_names"])
+    sutra_name_set = set(sutra_names)
+    expected_count = len(sutra_names)
+
+    for report_label in ("serial", "concurrent", "parallel"):
+        report_payload = payload[report_label]
+        if report_payload.get("schema_version") != REPORT_SCHEMA_VERSION:
+            raise ValueError(
+                f"{report_label} report schema mismatch: {report_payload.get('schema_version')}"
+            )
+        if report_payload.get("doctrine_fidelity") != DOCTRINE_FIDELITY_TAG:
+            raise ValueError(
+                f"{report_label} doctrine mismatch: {report_payload.get('doctrine_fidelity')}"
+            )
+
+        executions = report_payload.get("executions", [])
+        if len(executions) != expected_count:
+            raise ValueError(
+                f"{report_label} execution count mismatch: expected {expected_count}, got {len(executions)}"
+            )
+        execution_names = [entry.get("name") for entry in executions]
+        if set(execution_names) != sutra_name_set:
+            raise ValueError(f"{report_label} execution names do not match sutra inventory")
+
+    scalars = payload["runtime_scalars"]
+    parse_exact_rational(str(scalars["grvq_beta_scale"]))
+    parse_exact_rational(str(scalars["grvq_gamma_scale"]))
+    parse_exact_rational(str(scalars["engine_drift_threshold"]))
+
+
+def validate_benchmark_bundle_set(bundles: Sequence[HybridSimulationBundle]) -> None:
+    if not bundles:
+        raise ValueError("Benchmark bundle set cannot be empty")
+
+    inventory_hash = compute_sutra_inventory_hash(bundles[0].sutra_names)
+    for bundle in bundles:
+        validate_bundle_semantics(bundle.to_dict())
+        current_hash = compute_sutra_inventory_hash(bundle.sutra_names)
+        if current_hash != inventory_hash:
+            raise ValueError("Benchmark bundle set contains mixed sutra inventories")
+
 
 def _parse_mode(value: str) -> SutraMode:
     try:
@@ -304,7 +350,7 @@ def run_hybrid_bundle(
     serial_report = simulator.run_serial(value, mode=mode)
     concurrent_report = simulator.run_concurrent(value, mode=mode)
     parallel_report = simulator.run_parallel(value, mode=mode)
-    return HybridSimulationBundle(
+    bundle = HybridSimulationBundle(
         initial_value=value,
         sutra_names=sutra_names,
         serial=serial_report,
@@ -312,6 +358,8 @@ def run_hybrid_bundle(
         parallel=parallel_report,
         runtime_scalars=scalar_config,
     )
+    validate_bundle_semantics(bundle.to_dict())
+    return bundle
 
 
 def run_benchmark_suite(
@@ -364,6 +412,7 @@ def persist_signature_bundle(
         "path": str(bundle_path.name),
         "sutra_count": len(payload["sutra_names"]),
         "initial_value": payload["initial_value"],
+        "sutra_inventory_hash": compute_sutra_inventory_hash(payload["sutra_names"]),
     }
     index_path = vault_dir / "index.jsonl"
     with index_path.open("a", encoding="utf-8") as handle:
@@ -398,11 +447,17 @@ def audit_signature_vault(vault_dir: Path) -> Dict[str, Any]:
     for line in lines:
         entry = json.loads(line)
         bundle_path = vault_dir / entry["path"]
+        payload = load_bundle_payload(bundle_path)
         bundle_id = verify_bundle_file(bundle_path)
         if entry["bundle_id"] != bundle_id:
             raise ValueError(
                 f"Index bundle_id mismatch for {bundle_path.name}: "
                 f"index={entry['bundle_id']} computed={bundle_id}"
+            )
+        inventory_hash = compute_sutra_inventory_hash(payload["sutra_names"])
+        if entry.get("sutra_inventory_hash") != inventory_hash:
+            raise ValueError(
+                f"Index sutra_inventory_hash mismatch for {bundle_path.name}"
             )
         checked += 1
 

--- a/hybrid_sutra_platform.py
+++ b/hybrid_sutra_platform.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from fractions import Fraction
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Set
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
 
 from sutra_simulator import (
     DOCTRINE_FIDELITY_TAG,
@@ -53,6 +53,66 @@ def runtime_environment_metadata() -> Dict[str, Any]:
         "platform": platform.platform(),
         "git_commit": _resolve_git_commit(),
     }
+
+
+
+
+def compute_sutra_inventory_hash(sutra_names: Sequence[str]) -> str:
+    canonical = "\n".join(sorted(sutra_names))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def build_benchmark_matrix(bundles: Sequence[HybridSimulationBundle]) -> Dict[str, Any]:
+    matrix_rows: List[Dict[str, Any]] = []
+    for bundle in bundles:
+        matrix_rows.append(
+            {
+                "seed": str(bundle.initial_value),
+                "sutra_count": len(bundle.sutra_names),
+                "serial_wall_time_ns": bundle.serial.wall_time_ns,
+                "concurrent_wall_time_ns": bundle.concurrent.wall_time_ns,
+                "parallel_wall_time_ns": bundle.parallel.wall_time_ns,
+                "serial_aggregate": str(bundle.serial.aggregate),
+                "concurrent_aggregate": str(bundle.concurrent.aggregate),
+                "parallel_aggregate": str(bundle.parallel.aggregate),
+            }
+        )
+
+    return {
+        "benchmark_protocol_version": BENCHMARK_PROTOCOL_VERSION,
+        "rows": matrix_rows,
+    }
+
+
+def write_benchmark_matrix(
+    bundles: Sequence[HybridSimulationBundle],
+    path: Path,
+) -> None:
+    matrix = build_benchmark_matrix(bundles)
+    path.write_text(json.dumps(matrix, indent=2))
+
+
+def write_reproducibility_manifest(
+    bundles: Sequence[HybridSimulationBundle],
+    path: Path,
+) -> None:
+    if not bundles:
+        raise ValueError("Cannot write manifest for empty benchmark bundle set")
+
+    first = bundles[0]
+    manifest = {
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        "report_schema_version": REPORT_SCHEMA_VERSION,
+        "benchmark_protocol_version": BENCHMARK_PROTOCOL_VERSION,
+        "doctrine_fidelity": DOCTRINE_FIDELITY_TAG,
+        "runtime_environment": runtime_environment_metadata(),
+        "runtime_scalars": first.runtime_scalars.to_dict(),
+        "sutra_inventory_hash": compute_sutra_inventory_hash(first.sutra_names),
+        "seed_count": len(bundles),
+        "seeds": [str(bundle.initial_value) for bundle in bundles],
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    path.write_text(json.dumps(manifest, indent=2))
 
 
 def parse_exact_rational(raw: str) -> Fraction:
@@ -442,6 +502,16 @@ def build_cli() -> argparse.ArgumentParser:
         type=Path,
         help="Audit an existing signature vault and verify bundle/index integrity",
     )
+    parser.add_argument(
+        "--benchmark-matrix-output",
+        type=Path,
+        help="Optional path to write benchmark matrix JSON for benchmark suites",
+    )
+    parser.add_argument(
+        "--manifest-output",
+        type=Path,
+        help="Optional path to write reproducibility manifest JSON",
+    )
     return parser
 
 
@@ -482,6 +552,12 @@ def main() -> None:
                     run_label=args.run_label,
                 )
                 print(f"Persisted bundle {persisted.bundle_id} -> {persisted.path}")
+        if args.benchmark_matrix_output:
+            write_benchmark_matrix(bundles, args.benchmark_matrix_output)
+            print(f"Benchmark matrix written to {args.benchmark_matrix_output}")
+        if args.manifest_output:
+            write_reproducibility_manifest(bundles, args.manifest_output)
+            print(f"Reproducibility manifest written to {args.manifest_output}")
         return
 
     bundle = run_hybrid_bundle(
@@ -506,6 +582,10 @@ def main() -> None:
             run_label=args.run_label,
         )
         print(f"Persisted bundle {persisted.bundle_id} -> {persisted.path}")
+
+    if args.manifest_output:
+        write_reproducibility_manifest([bundle], args.manifest_output)
+        print(f"Reproducibility manifest written to {args.manifest_output}")
 
 
 if __name__ == "__main__":

--- a/scripts/validate_hsqcp_contracts.py
+++ b/scripts/validate_hsqcp_contracts.py
@@ -1,0 +1,90 @@
+"""Static contract validator for HSQCP runtime/schema invariants.
+
+This validator avoids runtime dependency loading and verifies that core files keep
+required schema/version/field invariants synchronized.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def _require(text: str, needle: str, source: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"Missing required token in {source}: {needle}")
+
+
+def validate_platform_contract() -> None:
+    text = _read("hybrid_sutra_platform.py")
+    required = [
+        'BUNDLE_SCHEMA_VERSION = "hsqcp.bundle.v1"',
+        'BENCHMARK_PROTOCOL_VERSION = "hsqcp.benchmark.v1"',
+        '"runtime_scalars"',
+        '"runtime_environment"',
+        'def parse_exact_rational(raw: str) -> Fraction:',
+        'def validate_bundle_payload(payload: Dict[str, Any]) -> None:',
+        'def compute_bundle_id(payload: Dict[str, Any]) -> str:',
+        'def persist_signature_bundle(',
+        'def audit_signature_vault(vault_dir: Path) -> Dict[str, Any]:',
+        'def run_benchmark_suite(',
+    ]
+    for token in required:
+        _require(text, token, "hybrid_sutra_platform.py")
+
+
+def validate_simulator_contract() -> None:
+    text = _read("sutra_simulator.py")
+    required = [
+        'REPORT_SCHEMA_VERSION = "hsqcp.report.v1"',
+        'DOCTRINE_FIDELITY_TAG = "exact-symbolic-core"',
+        'wall_time_ns: int = 0',
+        'elapsed_ns: int',
+        '"wall_time_ns"',
+        '"elapsed_ns"',
+    ]
+    for token in required:
+        _require(text, token, "sutra_simulator.py")
+
+
+def validate_docs_contract() -> None:
+    schema = _read("docs/hsqcp_report_schema.md")
+    protocol = _read("docs/hsqcp_benchmark_protocol.md")
+
+    schema_required = [
+        "hsqcp.bundle.v1",
+        "hsqcp.report.v1",
+        "wall_time_ns",
+        "elapsed_ns",
+        "runtime_environment",
+        "runtime_scalars",
+    ]
+    for token in schema_required:
+        _require(schema, token, "docs/hsqcp_report_schema.md")
+
+    protocol_required = [
+        "hsqcp.benchmark.v1",
+        "serial mode",
+        "concurrent mode",
+        "parallel mode",
+        "Exact Rationals",
+    ]
+    for token in protocol_required:
+        _require(protocol, token, "docs/hsqcp_benchmark_protocol.md")
+
+
+def main() -> None:
+    validate_platform_contract()
+    validate_simulator_contract()
+    validate_docs_contract()
+    print("HSQCP static contract validation passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_hsqcp_contracts.py
+++ b/scripts/validate_hsqcp_contracts.py
@@ -37,6 +37,8 @@ def validate_platform_contract() -> None:
         'def compute_sutra_inventory_hash(sutra_names: Sequence[str]) -> str:',
         'def build_benchmark_matrix(bundles: Sequence[HybridSimulationBundle]) -> Dict[str, Any]:',
         'def write_reproducibility_manifest(',
+        'def validate_bundle_semantics(payload: Dict[str, Any]) -> None:',
+        'def validate_benchmark_bundle_set(bundles: Sequence[HybridSimulationBundle]) -> None:',
     ]
     for token in required:
         _require(text, token, "hybrid_sutra_platform.py")
@@ -67,6 +69,7 @@ def validate_docs_contract() -> None:
         "elapsed_ns",
         "runtime_environment",
         "runtime_scalars",
+        "Semantic Validation Rules",
     ]
     for token in schema_required:
         _require(schema, token, "docs/hsqcp_report_schema.md")
@@ -79,6 +82,7 @@ def validate_docs_contract() -> None:
         "Exact Rationals",
         "Benchmark Matrix Artifact",
         "Reproducibility Manifest",
+        "Benchmark Set Consistency",
     ]
     for token in protocol_required:
         _require(protocol, token, "docs/hsqcp_benchmark_protocol.md")

--- a/scripts/validate_hsqcp_contracts.py
+++ b/scripts/validate_hsqcp_contracts.py
@@ -34,6 +34,9 @@ def validate_platform_contract() -> None:
         'def persist_signature_bundle(',
         'def audit_signature_vault(vault_dir: Path) -> Dict[str, Any]:',
         'def run_benchmark_suite(',
+        'def compute_sutra_inventory_hash(sutra_names: Sequence[str]) -> str:',
+        'def build_benchmark_matrix(bundles: Sequence[HybridSimulationBundle]) -> Dict[str, Any]:',
+        'def write_reproducibility_manifest(',
     ]
     for token in required:
         _require(text, token, "hybrid_sutra_platform.py")
@@ -74,6 +77,8 @@ def validate_docs_contract() -> None:
         "concurrent mode",
         "parallel mode",
         "Exact Rationals",
+        "Benchmark Matrix Artifact",
+        "Reproducibility Manifest",
     ]
     for token in protocol_required:
         _require(protocol, token, "docs/hsqcp_benchmark_protocol.md")

--- a/sutra_simulator.py
+++ b/sutra_simulator.py
@@ -2,11 +2,11 @@
 
 This module exposes a :class:`HybridQuantumClassicalSimulator` that can execute
 the entire sutra corpus serially, concurrently (multi-threaded) or in parallel
-across processes.  It wraps :class:`sutra_repository.SutraRepository` and keeps
+across processes. It wraps :class:`sutra_repository.SutraRepository` and keeps
 track of execution timings, intermediate artefacts and aggregation logic so the
 caller can fuse the classical and quantum contributions in a single place.
 
-The implementation is intentionally free of pseudo code.  Every helper is fully
+The implementation is intentionally free of pseudo code. Every helper is fully
 implemented and can be used programmatically or from higher-level CLIs (such as
 ``sutra_orchestrator.py``).
 """
@@ -14,11 +14,15 @@ implemented and can be used programmatically or from higher-level CLIs (such as
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
-from time import perf_counter
+from datetime import datetime, timezone
+from time import perf_counter_ns
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed
 
 from sutra_repository import SutraRepository, SutraContext, SutraMode
+
+REPORT_SCHEMA_VERSION = "hsqcp.report.v1"
+DOCTRINE_FIDELITY_TAG = "exact-symbolic-core"
 
 ArgumentResolver = Callable[[str, Any, SutraContext, Any], Tuple[Tuple[Any, ...], Dict[str, Any]]]
 
@@ -29,7 +33,7 @@ class SutraExecution:
 
     name: str
     output: Any
-    elapsed: float
+    elapsed_ns: int
 
 
 @dataclass
@@ -40,18 +44,26 @@ class SimulationReport:
     initial_value: Any
     executions: List[SutraExecution] = field(default_factory=list)
     aggregate: Any = None
-    wall_time: float = 0.0
+    wall_time_ns: int = 0
+    schema_version: str = REPORT_SCHEMA_VERSION
+    doctrine_fidelity: str = DOCTRINE_FIDELITY_TAG
+    generated_at_utc: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialise the report to a plain dictionary for logging or storage."""
 
         return {
+            "schema_version": self.schema_version,
+            "doctrine_fidelity": self.doctrine_fidelity,
+            "generated_at_utc": self.generated_at_utc,
             "mode": self.mode.name,
             "initial_value": self.initial_value,
             "aggregate": self.aggregate,
-            "wall_time": self.wall_time,
+            "wall_time_ns": self.wall_time_ns,
             "executions": [
-                {"name": exec.name, "elapsed": exec.elapsed, "output": exec.output}
+                {"name": exec.name, "elapsed_ns": exec.elapsed_ns, "output": exec.output}
                 for exec in self.executions
             ],
         }
@@ -61,7 +73,7 @@ def _build_context(template: SutraContext, *, mode: Optional[SutraMode] = None) 
     """Clone the provided context with optional mode override.
 
     ``SutraContext`` instances carry GPU handles and other non-serialisable
-    attributes.  :func:`dataclasses.replace` is used to avoid mutating the
+    attributes. :func:`dataclasses.replace` is used to avoid mutating the
     original reference while preventing inadvertent sharing of execution state.
     """
 
@@ -69,7 +81,7 @@ def _build_context(template: SutraContext, *, mode: Optional[SutraMode] = None) 
     if mode is not None:
         context.mode = mode
     # Disable nested parallelism inside helpers when higher-level scheduling is
-    # applied.  This avoids recursive thread spawning.
+    # applied. This avoids recursive thread spawning.
     context.parallel = False
     return context
 
@@ -83,17 +95,17 @@ def _execute_sutra(
     """Execute a sutra inside the current process."""
 
     repo = SutraRepository(context)
-    start = perf_counter()
+    start = perf_counter_ns()
     result = repo.call_sutra(name, *args, ctx=context, **kwargs)
-    elapsed = perf_counter() - start
-    return SutraExecution(name=name, output=result, elapsed=elapsed)
+    elapsed_ns = perf_counter_ns() - start
+    return SutraExecution(name=name, output=result, elapsed_ns=elapsed_ns)
 
 
 def _execute_sutra_process(payload: Dict[str, Any]) -> SutraExecution:
     """Execute a sutra in a worker process.
 
     ``SutraContext`` may contain objects that are not picklable (such as CUDA
-    handles).  For multi-processing we rebuild a lightweight context using only
+    handles). For multi-processing we rebuild a lightweight context using only
     primitive fields from the payload.
     """
 
@@ -168,10 +180,10 @@ class HybridQuantumClassicalSimulator:
         initial_value: Any = value
         aggregate_value: Any = value
         report = SimulationReport(mode=context.mode, initial_value=value)
-        wall_start = perf_counter()
+        wall_start = perf_counter_ns()
 
         for name in self._sutra_names:
-            start = perf_counter()
+            start = perf_counter_ns()
             args, call_kwargs = self._resolve_arguments(
                 name, aggregate_value, context, initial_value
             )
@@ -181,12 +193,12 @@ class HybridQuantumClassicalSimulator:
                 ctx=context,
                 **call_kwargs,
             )
-            elapsed = perf_counter() - start
-            execution = SutraExecution(name=name, output=aggregate_value, elapsed=elapsed)
+            elapsed_ns = perf_counter_ns() - start
+            execution = SutraExecution(name=name, output=aggregate_value, elapsed_ns=elapsed_ns)
             report.executions.append(execution)
             report.aggregate = self._aggregation(report.aggregate, execution)
 
-        report.wall_time = perf_counter() - wall_start
+        report.wall_time_ns = perf_counter_ns() - wall_start
         if report.aggregate is None:
             report.aggregate = aggregate_value
         return report
@@ -201,7 +213,7 @@ class HybridQuantumClassicalSimulator:
 
         context = _build_context(self._base_context, mode=mode)
         report = SimulationReport(mode=context.mode, initial_value=value)
-        wall_start = perf_counter()
+        wall_start = perf_counter_ns()
 
         def submit(name: str) -> SutraExecution:
             local_context = _build_context(context, mode=context.mode)
@@ -218,7 +230,7 @@ class HybridQuantumClassicalSimulator:
         report.executions.sort(key=lambda exec: exec.name)
         for execution in report.executions:
             report.aggregate = self._aggregation(report.aggregate, execution)
-        report.wall_time = perf_counter() - wall_start
+        report.wall_time_ns = perf_counter_ns() - wall_start
         return report
 
     def run_parallel(
@@ -231,7 +243,7 @@ class HybridQuantumClassicalSimulator:
 
         context = _build_context(self._base_context, mode=mode)
         report = SimulationReport(mode=context.mode, initial_value=value)
-        wall_start = perf_counter()
+        wall_start = perf_counter_ns()
 
         context_kwargs = {
             "mode": context.mode,
@@ -267,13 +279,14 @@ class HybridQuantumClassicalSimulator:
         report.executions.sort(key=lambda exec: exec.name)
         for execution in report.executions:
             report.aggregate = self._aggregation(report.aggregate, execution)
-        report.wall_time = perf_counter() - wall_start
+        report.wall_time_ns = perf_counter_ns() - wall_start
         return report
 
 
 __all__ = [
+    "DOCTRINE_FIDELITY_TAG",
+    "REPORT_SCHEMA_VERSION",
     "HybridQuantumClassicalSimulator",
     "SimulationReport",
     "SutraExecution",
 ]
-


### PR DESCRIPTION
### Motivation
- Formalize deterministic tri-modal benchmarking and machine-readable artifact contracts for the 29-sutra hybrid runtime so results are reproducible and auditable. 
- Provide explicit runtime scalar governance and a signature-vault for persisting indexed benchmark bundles with verifiable payload hashes. 
- Harden simulator reporting by adding schema and doctrine fidelity markers and move timing to nanosecond resolution for stable comparisons.

### Description
- Add documentation files `docs/formal_asset_register.md`, `docs/hsqcp_benchmark_protocol.md`, and `docs/hsqcp_report_schema.md` describing asset register, benchmark protocol (`hsqcp.benchmark.v1`), and bundle/report schema (`hsqcp.bundle.v1` / `hsqcp.report.v1`).
- Extend `sutra_simulator.py` with `REPORT_SCHEMA_VERSION` and `DOCTRINE_FIDELITY_TAG`, change timing to nanoseconds, and enrich `SimulationReport` with schema, doctrine fidelity, and UTC timestamp metadata and updated serialization keys.
- Implement new runtime governance and bundling features in `hybrid_sutra_platform.py`, including `RuntimeScalarConfig`, `HybridSimulationBundle` with validation (`validate_bundle_payload`), `compute_bundle_id`, `persist_signature_bundle`, `audit_signature_vault`, `run_benchmark_suite`, exact rational parsing (`parse_exact_rational`), runtime environment metadata, and bundle verification utilities.
- Add CLI options in `hybrid_sutra_platform.py` for seed lists (`--benchmark-seeds`), scalar overrides (`--grvq-beta-scale`, `--grvq-gamma-scale`, `--engine-rebuild-interval`, `--engine-drift-threshold`), vault persistence (`--vault-dir`, `--run-label`) and auditing (`--audit-vault`), and change the main input to accept exact rationals.
- Improve sutra filtering by creating deterministic name filters via `SutraRepository.list_sutras()` and enforce top-level bundle schema invariants before persisting artifacts.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae5110a0cc8332ac17c26043d4230c)